### PR TITLE
chore: Remove DECLARE_* macros, as those are not needed in the same TU

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,10 +47,10 @@ jobs:
 
       - name: CLI example help
         run: |
-          cd examples/cli
+          cd build/examples/cli
           ./monkas --help || true
 
       - name: CLI example nerdstats/dumppackets
         run: |
-          cd examples/cli
+          cd build/examples/cli
           timeout --preserve-status 1 ./monkas -nerdstats -dumppackets || true

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -4,22 +4,19 @@
 #include <network/NetworkAddress.hpp>
 #include <spdlog/spdlog.h>
 
-DECLARE_bool(nerdstats);
 DEFINE_bool(nerdstats, false, "Enable stats for nerds");
 
-DECLARE_bool(dumppackets);
 DEFINE_bool(dumppackets, false, "Enable dumping of rtnl packets");
 
-DECLARE_uint32(family);
 DEFINE_uint32(family, 0, "Preferred address family <4|6>");
 
-DECLARE_string(log_level);
 DEFINE_string(log_level, "info", "Set log level: trace, debug, info, warn, err, critical, off");
 
 /**
  * @brief Entry point for the rtnetlink network monitor CLI application.
  *
- * Parses command-line flags to configure logging level, monitoring options, and preferred IP family, then initializes and runs the network monitor. Returns the monitor's exit code.
+ * Parses command-line flags to configure logging level, monitoring options, and preferred IP family, then initializes
+ * and runs the network monitor. Returns the monitor's exit code.
  *
  * @return int Exit code from the network monitor.
  */

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -1,5 +1,4 @@
 #include <gflags/gflags.h>
-#include <gflags/gflags_declare.h>
 #include <monitor/RtnlNetworkMonitor.hpp>
 #include <network/NetworkAddress.hpp>
 #include <spdlog/spdlog.h>


### PR DESCRIPTION
Closes #17 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Improved formatting in function comments for better readability.

- **Chores**
  - Streamlined command-line flag definitions without affecting app behavior.
  - Updated workflow to run CLI commands from the build output directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->