### PR TITLE
refactor: Refactor log level parsing to use spdlog::level::from_str with error handling

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -25,6 +25,7 @@ int main(int argc, char *argv[])
     gflags::SetUsageMessage("<flags>\n");
     gflags::ParseCommandLineFlags(&argc, &argv, true);
 
+    std::transform(FLAGS_log_level.begin(), FLAGS_log_level.end(), FLAGS_log_level.begin(), ::tolower);
     if (auto level = spdlog::level::from_str(FLAGS_log_level); level == spdlog::level::off && FLAGS_log_level != "off")
     {
         SPDLOG_ERROR("invalid log level '{}', using 'info' instead", FLAGS_log_level);


### PR DESCRIPTION
Closes #13 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for invalid log level strings in the CLI. Invalid values now trigger an error message and default to the "info" log level.
- **Refactor**
	- Streamlined the process for setting log levels, reducing complexity and improving maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->