### PR TITLE
feat: Add enumeration done event and exit_after_enumeration flag to CLI and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,4 +129,4 @@ jobs:
 
       - name: CLI example nerdstats/dumppackets
         run: |
-          timeout --preserve-status 1 ../build/examples/cli/monka -nerdstats -dumppackets || true
+          ../build/examples/cli/monka --log-level=trace --nerdstats --dumppackets --exit-after-enumeration

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -8,6 +8,8 @@ DEFINE_bool(nerdstats, false, "Enable stats for nerds");
 
 DEFINE_bool(dumppackets, false, "Enable dumping of rtnl packets");
 
+DEFINE_bool(exit_after_enumeration, false, "Exit after enumeration is done");
+
 DEFINE_uint32(family, 0, "Preferred address family <4|6>");
 
 DEFINE_string(log_level, "info", "Set log level: trace, debug, info, warn, err, critical, off");
@@ -64,6 +66,15 @@ int main(int argc, char *argv[])
     });
     std::ignore = mon.addNetworkAddressListener([](const network::Interface &iface, const NetworkAddresses &addresses) {
         spdlog::info("{} changed addresses to {}", iface, fmt::join(addresses, ", "));
+    });
+
+    std::ignore = mon.addEnumerationDoneListener([&mon]() {
+        spdlog::info("Enumeration done");
+        if (FLAGS_exit_after_enumeration)
+        {
+            spdlog::info("Exiting after enumeration is done");
+            mon.stop();
+        }
     });
 
     return mon.run();

--- a/include/monkas/monitor/RtnlNetworkMonitor.hpp
+++ b/include/monkas/monitor/RtnlNetworkMonitor.hpp
@@ -59,6 +59,10 @@ using NetworkAddressBroadcaster = Observable<network::Interface, std::reference_
 using NetworkAddressListener = NetworkAddressBroadcaster::Observer;
 using NetworkAddressListenerToken = NetworkAddressBroadcaster::Token;
 
+using EnumerationDoneBroadcaster = Observable<>;
+using EnumerationDoneListener = EnumerationDoneBroadcaster::Observer;
+using EnumerationDoneListenerToken = EnumerationDoneBroadcaster::Token;
+
 class RtnlNetworkMonitor
 {
   public:
@@ -74,6 +78,9 @@ class RtnlNetworkMonitor
 
     [[nodiscard]] NetworkAddressListenerToken addNetworkAddressListener(const NetworkAddressListener &listener);
     void removeNetworkAddressListener(const NetworkAddressListenerToken &token);
+
+    [[nodiscard]] EnumerationDoneListenerToken addEnumerationDoneListener(const EnumerationDoneListener &listener);
+    void removeEnumerationDoneListener(const EnumerationDoneListenerToken &token);
 
   private:
     void receiveAndProcess();
@@ -163,5 +170,6 @@ class RtnlNetworkMonitor
     InterfacesBroadcaster m_interfacesBroadcaster;
     OperationalStateBroadcaster m_operationalStateBroadcaster;
     NetworkAddressBroadcaster m_networkAddressBroadcaster;
+    EnumerationDoneBroadcaster m_enumerationDoneBroadcaster;
 };
 } // namespace monkas


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option to automatically exit the CLI application after network enumeration completes.
  - Introduced event notifications for when network enumeration is finished.
- **Chores**
  - Updated the CI workflow to use the new exit-after-enumeration option and enhanced logging for CLI examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->