### PR TITLE
feat: Add gateway address change listeners and notification APIs to network monitor

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -67,7 +67,9 @@ int main(int argc, char *argv[])
     std::ignore = mon.addNetworkAddressListener([](const network::Interface &iface, const NetworkAddresses &addresses) {
         spdlog::info("{} changed addresses to {}", iface, fmt::join(addresses, ", "));
     });
-
+    std::ignore = mon.addGatewayAddressListener([](const network::Interface &iface, const ip::Address &gateway) {
+        spdlog::info("{} changed gateway address to {}", iface, gateway);
+    });
     std::ignore = mon.addEnumerationDoneListener([&mon]() {
         spdlog::info("Enumeration done");
         if (FLAGS_exit_after_enumeration)

--- a/include/monkas/monitor/RtnlNetworkMonitor.hpp
+++ b/include/monkas/monitor/RtnlNetworkMonitor.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "ip/Address.hpp"
 #include <chrono>
 #include <cstdint>
 #include <functional>
@@ -50,6 +51,7 @@ using Interfaces = std::set<network::Interface>;
 using InterfacesBroadcaster = Observable<std::reference_wrapper<const Interfaces>>;
 using InterfacesListener = InterfacesBroadcaster::Observer;
 using InterfacesListenerToken = InterfacesBroadcaster::Token;
+
 using OperationalState = NetworkInterfaceStatusTracker::OperationalState;
 using OperationalStateBroadcaster = Observable<network::Interface, OperationalState>;
 using OperationalStateListener = OperationalStateBroadcaster::Observer;
@@ -58,6 +60,10 @@ using OperationalStateListenerToken = OperationalStateBroadcaster::Token;
 using NetworkAddressBroadcaster = Observable<network::Interface, std::reference_wrapper<const NetworkAddresses>>;
 using NetworkAddressListener = NetworkAddressBroadcaster::Observer;
 using NetworkAddressListenerToken = NetworkAddressBroadcaster::Token;
+
+using GatewayAddressBroadcaster = Observable<network::Interface, std::reference_wrapper<const ip::Address>>;
+using GatewayAddressListener = GatewayAddressBroadcaster::Observer;
+using GatewayAddressListenerToken = GatewayAddressBroadcaster::Token;
 
 using EnumerationDoneBroadcaster = Observable<>;
 using EnumerationDoneListener = EnumerationDoneBroadcaster::Observer;
@@ -78,6 +84,12 @@ class RtnlNetworkMonitor
 
     [[nodiscard]] NetworkAddressListenerToken addNetworkAddressListener(const NetworkAddressListener &listener);
     void removeNetworkAddressListener(const NetworkAddressListenerToken &token);
+
+    [[nodiscard]] GatewayAddressListenerToken addGatewayAddressListener(const GatewayAddressListener &listener);
+    void removeGatewayAddressListener(const GatewayAddressListenerToken &token);
+
+    [[nodiscard]] NetworkInterfaceStatusTracker &ensureTrackerForInterface(int ifIndex);
+    [[nodiscard]] NetworkInterfaceStatusTracker &ensureTrackerForInterface(const network::Interface &iface);
 
     [[nodiscard]] EnumerationDoneListenerToken addEnumerationDoneListener(const EnumerationDoneListener &listener);
     void removeEnumerationDoneListener(const EnumerationDoneListenerToken &token);
@@ -170,6 +182,7 @@ class RtnlNetworkMonitor
     InterfacesBroadcaster m_interfacesBroadcaster;
     OperationalStateBroadcaster m_operationalStateBroadcaster;
     NetworkAddressBroadcaster m_networkAddressBroadcaster;
+    GatewayAddressBroadcaster m_gatewayAddressBroadcaster;
     EnumerationDoneBroadcaster m_enumerationDoneBroadcaster;
 };
 } // namespace monkas

--- a/src/monkas/monitor/RtnlNetworkMonitor.cpp
+++ b/src/monkas/monitor/RtnlNetworkMonitor.cpp
@@ -507,6 +507,11 @@ void RtnlNetworkMonitor::broadcastChanges()
                                                   tracker.networkAddresses());
             tracker.clearFlag(DirtyFlag::NetworkAddressesChanged);
         }
+        if (m_gatewayAddressBroadcaster.hasListeners() && tracker.isDirty(DirtyFlag::GatewayAddressChanged))
+        {
+            m_gatewayAddressBroadcaster.broadcast(network::Interface{index, tracker.name()}, tracker.gatewayAddress());
+            tracker.clearFlag(DirtyFlag::GatewayAddressChanged);
+        }
     }
 }
 

--- a/src/monkas/monitor/RtnlNetworkMonitor.cpp
+++ b/src/monkas/monitor/RtnlNetworkMonitor.cpp
@@ -121,6 +121,16 @@ void RtnlNetworkMonitor::removeNetworkAddressListener(const NetworkAddressListen
     m_networkAddressBroadcaster.removeListener(token);
 }
 
+GatewayAddressListenerToken RtnlNetworkMonitor::addGatewayAddressListener(const GatewayAddressListener &listener)
+{
+    return m_gatewayAddressBroadcaster.addListener(listener);
+}
+
+void RtnlNetworkMonitor::removeGatewayAddressListener(const GatewayAddressListenerToken &token)
+{
+    m_gatewayAddressBroadcaster.removeListener(token);
+}
+
 EnumerationDoneListenerToken RtnlNetworkMonitor::addEnumerationDoneListener(const EnumerationDoneListener &listener)
 {
     return m_enumerationDoneBroadcaster.addListener(listener);


### PR DESCRIPTION
Closes #42 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for listening to gateway address changes on network interfaces. Users can now receive notifications when a gateway address changes, with details about the affected interface and new address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->