### PR TITLE
feat: Refactor Ethernet watcher into separate MAC and broadcast address watchers

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -85,9 +85,14 @@ int main(int argc, char *argv[])
             spdlog::info("{} changed gateway address to {}", iface, gateway);
         },
         true);
-    std::ignore = mon.addEthernetAddressWatcher(
+    std::ignore = mon.addMacAddressWatcher(
         [](const network::Interface &iface, const ethernet::Address &mac) {
             spdlog::info("{} changed ethernet address to {}", iface, mac);
+        },
+        true);
+    std::ignore = mon.addBroadcastAddressWatcher(
+        [](const network::Interface &iface, const ethernet::Address &broadcast) {
+            spdlog::info("{} changed broadcast address to {}", iface, broadcast);
         },
         true);
     std::ignore = mon.addEnumerationDoneWatcher([&mon]() {

--- a/include/monkas/monitor/RtnlNetworkMonitor.hpp
+++ b/include/monkas/monitor/RtnlNetworkMonitor.hpp
@@ -207,7 +207,7 @@ class RtnlNetworkMonitor
     NetworkAddressNotifier m_networkAddressNotifier;
     GatewayAddressNotifier m_gatewayAddressNotifier;
     MacAddressNotifier m_macAddressNotifier;
-    MacAddressNotifier m_broadcastAddressNotifier;
+    BroadcastAddressNotifier m_broadcastAddressNotifier;
     EnumerationDoneNotifier m_enumerationDoneNotifier;
 };
 } // namespace monkas

--- a/include/monkas/monitor/RtnlNetworkMonitor.hpp
+++ b/include/monkas/monitor/RtnlNetworkMonitor.hpp
@@ -65,9 +65,13 @@ using GatewayAddressNotifier = Watchable<const network::Interface, const ip::Add
 using GatewayAddressWatcher = GatewayAddressNotifier::Watcher;
 using GatewayAddressWatcherToken = GatewayAddressNotifier::Token;
 
-using EthernetAddressNotifier = Watchable<network::Interface, const ethernet::Address>;
-using EthernetAddressWatcher = EthernetAddressNotifier::Watcher;
-using EthernetAddressWatcherToken = EthernetAddressNotifier::Token;
+using MacAddressNotifier = Watchable<network::Interface, const ethernet::Address>;
+using MacAddressWatcher = MacAddressNotifier::Watcher;
+using MacAddressWatcherToken = MacAddressNotifier::Token;
+
+using BroadcastAddressNotifier = Watchable<network::Interface, const ethernet::Address>;
+using BroadcastAddressWatcher = BroadcastAddressNotifier::Watcher;
+using BroadcastAddressWatcherToken = BroadcastAddressNotifier::Token;
 
 using EnumerationDoneNotifier = Watchable<>;
 using EnumerationDoneWatcher = EnumerationDoneNotifier::Watcher;
@@ -97,14 +101,14 @@ class RtnlNetworkMonitor
                                                                       bool initialSnapshot = false);
     void removeGatewayAddressWatcher(const GatewayAddressWatcherToken &token);
 
-    [[nodiscard]] EthernetAddressWatcherToken addMacAddressWatcher(const EthernetAddressWatcher &watcher,
-                                                                   bool initialSnapshot = true);
-    void removeMacAddressWatcher(const EthernetAddressWatcherToken &token);
+    [[nodiscard]] MacAddressWatcherToken addMacAddressWatcher(const MacAddressWatcher &watcher,
+                                                              bool initialSnapshot = true);
+    void removeMacAddressWatcher(const MacAddressWatcherToken &token);
 
-    [[nodiscard]] EthernetAddressWatcherToken addBroadcastAddressWatcher(const EthernetAddressWatcher &watcher,
-                                                                         bool initialSnapshot = false);
+    [[nodiscard]] BroadcastAddressWatcherToken addBroadcastAddressWatcher(const MacAddressWatcher &watcher,
+                                                                          bool initialSnapshot = false);
 
-    void removeBroadcastAddressWatcher(const EthernetAddressWatcherToken &token);
+    void removeBroadcastAddressWatcher(const BroadcastAddressWatcherToken &token);
 
     // enumeration done watcher is called when enumeration is done, or immediately if enumeration is already done
     // the optional return value is used to indicate that enumeration is already done
@@ -202,8 +206,8 @@ class RtnlNetworkMonitor
     OperationalStateNotifier m_operationalStateNotifier;
     NetworkAddressNotifier m_networkAddressNotifier;
     GatewayAddressNotifier m_gatewayAddressNotifier;
-    EthernetAddressNotifier m_macAddressNotifier;
-    EthernetAddressNotifier m_broadcastAddressNotifier;
+    MacAddressNotifier m_macAddressNotifier;
+    MacAddressNotifier m_broadcastAddressNotifier;
     EnumerationDoneNotifier m_enumerationDoneNotifier;
 };
 } // namespace monkas

--- a/include/monkas/monitor/RtnlNetworkMonitor.hpp
+++ b/include/monkas/monitor/RtnlNetworkMonitor.hpp
@@ -97,9 +97,14 @@ class RtnlNetworkMonitor
                                                                       bool initialSnapshot = false);
     void removeGatewayAddressWatcher(const GatewayAddressWatcherToken &token);
 
-    [[nodiscard]] EthernetAddressWatcherToken addEthernetAddressWatcher(const EthernetAddressWatcher &watcher,
-                                                                        bool initialSnapshot = false);
-    void removeEthernetAddressWatcher(const EthernetAddressWatcherToken &token);
+    [[nodiscard]] EthernetAddressWatcherToken addMacAddressWatcher(const EthernetAddressWatcher &watcher,
+                                                                   bool initialSnapshot = true);
+    void removeMacAddressWatcher(const EthernetAddressWatcherToken &token);
+
+    [[nodiscard]] EthernetAddressWatcherToken addBroadcastAddressWatcher(const EthernetAddressWatcher &watcher,
+                                                                         bool initialSnapshot = false);
+
+    void removeBroadcastAddressWatcher(const EthernetAddressWatcherToken &token);
 
     // enumeration done watcher is called when enumeration is done, or immediately if enumeration is already done
     // the optional return value is used to indicate that enumeration is already done
@@ -197,7 +202,8 @@ class RtnlNetworkMonitor
     OperationalStateNotifier m_operationalStateNotifier;
     NetworkAddressNotifier m_networkAddressNotifier;
     GatewayAddressNotifier m_gatewayAddressNotifier;
-    EthernetAddressNotifier m_ethernetAddressNotifier;
+    EthernetAddressNotifier m_macAddressNotifier;
+    EthernetAddressNotifier m_broadcastAddressNotifier;
     EnumerationDoneNotifier m_enumerationDoneNotifier;
 };
 } // namespace monkas

--- a/src/monkas/monitor/RtnlNetworkMonitor.cpp
+++ b/src/monkas/monitor/RtnlNetworkMonitor.cpp
@@ -185,8 +185,7 @@ void RtnlNetworkMonitor::removeGatewayAddressWatcher(const GatewayAddressWatcher
     m_gatewayAddressNotifier.removeWatcher(token);
 }
 
-EthernetAddressWatcherToken RtnlNetworkMonitor::addMacAddressWatcher(const EthernetAddressWatcher &watcher,
-                                                                     bool initialSnapshot)
+MacAddressWatcherToken RtnlNetworkMonitor::addMacAddressWatcher(const MacAddressWatcher &watcher, bool initialSnapshot)
 {
     if (initialSnapshot)
     {
@@ -199,13 +198,13 @@ EthernetAddressWatcherToken RtnlNetworkMonitor::addMacAddressWatcher(const Ether
     return m_macAddressNotifier.addWatcher(watcher);
 }
 
-void RtnlNetworkMonitor::removeMacAddressWatcher(const EthernetAddressWatcherToken &token)
+void RtnlNetworkMonitor::removeMacAddressWatcher(const MacAddressWatcherToken &token)
 {
     m_macAddressNotifier.removeWatcher(token);
 }
 
-EthernetAddressWatcherToken RtnlNetworkMonitor::addBroadcastAddressWatcher(const EthernetAddressWatcher &watcher,
-                                                                           bool initialSnapshot)
+BroadcastAddressWatcherToken RtnlNetworkMonitor::addBroadcastAddressWatcher(const BroadcastAddressWatcher &watcher,
+                                                                            bool initialSnapshot)
 {
     if (initialSnapshot)
     {
@@ -218,7 +217,7 @@ EthernetAddressWatcherToken RtnlNetworkMonitor::addBroadcastAddressWatcher(const
     return m_broadcastAddressNotifier.addWatcher(watcher);
 }
 
-void RtnlNetworkMonitor::removeBroadcastAddressWatcher(const EthernetAddressWatcherToken &token)
+void RtnlNetworkMonitor::removeBroadcastAddressWatcher(const BroadcastAddressWatcherToken &token)
 {
     m_broadcastAddressNotifier.removeWatcher(token);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for monitoring broadcast address changes on network interfaces, with notifications when these addresses are updated.
- **Refactor**
  - Renamed Ethernet address watcher functionality to MAC address watcher for improved clarity.
  - Separated MAC address and broadcast address watchers, allowing independent monitoring and notifications for each.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->