### PR TITLE
refactor: Rename EthernetAddress to MacAddress throughout the codebase

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -86,7 +86,7 @@ auto main(int argc, char *argv[]) -> int
         InitialSnapshotMode::InitialSnapshot);
     std::ignore = mon.addMacAddressWatcher(
         [](const network::Interface &iface, const ethernet::Address &mac) {
-            spdlog::info("{} changed mac address to {}", iface, mac);
+            spdlog::info("{} changed MAC address to {}", iface, mac);
         },
         InitialSnapshotMode::InitialSnapshot);
     std::ignore = mon.addBroadcastAddressWatcher(

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -86,7 +86,7 @@ auto main(int argc, char *argv[]) -> int
         InitialSnapshotMode::InitialSnapshot);
     std::ignore = mon.addMacAddressWatcher(
         [](const network::Interface &iface, const ethernet::Address &mac) {
-            spdlog::info("{} changed ethernet address to {}", iface, mac);
+            spdlog::info("{} changed mac address to {}", iface, mac);
         },
         InitialSnapshotMode::InitialSnapshot);
     std::ignore = mon.addBroadcastAddressWatcher(

--- a/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
+++ b/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
@@ -39,7 +39,7 @@ class NetworkInterfaceStatusTracker
     {
         NameChanged,
         OperationalStateChanged,
-        EthernetAddressChanged,
+        MacAddressChanged,
         BroadcastAddressChanged,
         GatewayAddressChanged,
         NetworkAddressesChanged,
@@ -57,8 +57,8 @@ class NetworkInterfaceStatusTracker
     [[nodiscard]] auto operationalState() const -> OperationalState;
     void setOperationalState(OperationalState operstate);
 
-    [[nodiscard]] auto ethernetAddress() const -> const ethernet::Address &;
-    void setEthernetAddress(const ethernet::Address &address);
+    [[nodiscard]] auto macAddress() const -> const ethernet::Address &;
+    void setMacAddress(const ethernet::Address &address);
 
     [[nodiscard]] auto broadcastAddress() const -> const ethernet::Address &;
     void setBroadcastAddress(const ethernet::Address &address);
@@ -87,7 +87,7 @@ class NetworkInterfaceStatusTracker
     // TODO: only use public api
     friend auto operator<<(std::ostream &o, const NetworkInterfaceStatusTracker &s) -> std::ostream &;
     std::string m_name;
-    ethernet::Address m_ethernetAddress;
+    ethernet::Address m_macAddress;
     ethernet::Address m_broadcastAddress;
     OperationalState m_operState{OperationalState::Unknown};
     NetworkAddresses m_networkAddresses;

--- a/src/monkas/monitor/NetworkInterfaceStatusTracker.cpp
+++ b/src/monkas/monitor/NetworkInterfaceStatusTracker.cpp
@@ -340,7 +340,7 @@ auto operator<<(std::ostream &o, const NetworkInterfaceStatusTracker &s) -> std:
     o << s.name();
     if (s.m_macAddress)
     {
-        o << " ether " << s.m_macAddress;
+        o << " mac " << s.m_macAddress;
     }
     if (s.m_broadcastAddress)
     {

--- a/src/monkas/monitor/NetworkInterfaceStatusTracker.cpp
+++ b/src/monkas/monitor/NetworkInterfaceStatusTracker.cpp
@@ -23,7 +23,7 @@ void logTrace(const T &t, NetworkInterfaceStatusTracker *that, const std::string
 
 NetworkInterfaceStatusTracker::NetworkInterfaceStatusTracker()
     : m_lastChanged(std::chrono::steady_clock::now())
-    , m_ethernetAddress{}
+    , m_macAddress{}
     , m_broadcastAddress{}
 {
 }
@@ -85,9 +85,9 @@ void NetworkInterfaceStatusTracker::setOperationalState(OperationalState opersta
     }
 }
 
-auto NetworkInterfaceStatusTracker::ethernetAddress() const -> const ethernet::Address &
+auto NetworkInterfaceStatusTracker::macAddress() const -> const ethernet::Address &
 {
-    return m_ethernetAddress;
+    return m_macAddress;
 }
 
 auto NetworkInterfaceStatusTracker::broadcastAddress() const -> const ethernet::Address &
@@ -95,13 +95,13 @@ auto NetworkInterfaceStatusTracker::broadcastAddress() const -> const ethernet::
     return m_broadcastAddress;
 }
 
-void NetworkInterfaceStatusTracker::setEthernetAddress(const ethernet::Address &address)
+void NetworkInterfaceStatusTracker::setMacAddress(const ethernet::Address &address)
 {
-    if (m_ethernetAddress != address)
+    if (m_macAddress != address)
     {
-        m_ethernetAddress = address;
-        touch(DirtyFlag::EthernetAddressChanged);
-        logTrace(address, this, "ethernet address changed to");
+        m_macAddress = address;
+        touch(DirtyFlag::MacAddressChanged);
+        logTrace(address, this, "mac address changed to");
     }
 }
 
@@ -288,7 +288,7 @@ auto operator<<(std::ostream &o, DirtyFlag d) -> std::ostream &
         return o << "NameChanged";
     case NetworkInterfaceStatusTracker::DirtyFlag::OperationalStateChanged:
         return o << "OperationalStateChanged";
-    case NetworkInterfaceStatusTracker::DirtyFlag::EthernetAddressChanged:
+    case NetworkInterfaceStatusTracker::DirtyFlag::MacAddressChanged:
         return o << "EthernetAddressChanged";
     case NetworkInterfaceStatusTracker::DirtyFlag::BroadcastAddressChanged:
         return o << "BroadcastAddressChanged";
@@ -338,9 +338,9 @@ auto operator<<(std::ostream &o, const DirtyFlags &d) -> std::ostream &
 auto operator<<(std::ostream &o, const NetworkInterfaceStatusTracker &s) -> std::ostream &
 {
     o << s.name();
-    if (s.m_ethernetAddress)
+    if (s.m_macAddress)
     {
-        o << " ether " << s.m_ethernetAddress;
+        o << " ether " << s.m_macAddress;
     }
     if (s.m_broadcastAddress)
     {

--- a/src/monkas/monitor/NetworkInterfaceStatusTracker.cpp
+++ b/src/monkas/monitor/NetworkInterfaceStatusTracker.cpp
@@ -289,7 +289,7 @@ auto operator<<(std::ostream &o, DirtyFlag d) -> std::ostream &
     case NetworkInterfaceStatusTracker::DirtyFlag::OperationalStateChanged:
         return o << "OperationalStateChanged";
     case NetworkInterfaceStatusTracker::DirtyFlag::MacAddressChanged:
-        return o << "EthernetAddressChanged";
+        return o << "MacAddressChanged";
     case NetworkInterfaceStatusTracker::DirtyFlag::BroadcastAddressChanged:
         return o << "BroadcastAddressChanged";
     case NetworkInterfaceStatusTracker::DirtyFlag::GatewayAddressChanged:

--- a/src/monkas/monitor/RtnlNetworkMonitor.cpp
+++ b/src/monkas/monitor/RtnlNetworkMonitor.cpp
@@ -210,8 +210,8 @@ auto RtnlNetworkMonitor::addMacAddressWatcher(const MacAddressWatcher &watcher, 
     {
         for (auto &[index, tracker] : m_trackers)
         {
-            watcher(network::Interface{index, tracker.name()}, tracker.ethernetAddress());
-            tracker.clearFlag(DirtyFlag::EthernetAddressChanged);
+            watcher(network::Interface{index, tracker.name()}, tracker.macAddress());
+            tracker.clearFlag(DirtyFlag::MacAddressChanged);
         }
     }
     return m_macAddressNotifier.addWatcher(watcher);
@@ -453,7 +453,7 @@ void RtnlNetworkMonitor::parseLinkMessage(const nlmsghdr *nlhdr, const ifinfomsg
         const auto *addr = static_cast<const uint8_t *>(mnl_attr_get_payload(attributes[IFLA_ADDRESS]));
         const auto len = mnl_attr_get_payload_len(attributes[IFLA_ADDRESS]);
         auto ethernetAddress = ethernet::Address::fromBytes(addr, len);
-        cacheEntry.setEthernetAddress(ethernetAddress);
+        cacheEntry.setMacAddress(ethernetAddress);
     }
     if (attributes[IFLA_BROADCAST] != nullptr)
     {
@@ -655,10 +655,10 @@ void RtnlNetworkMonitor::notifyChanges()
             m_gatewayAddressNotifier.notify(network::Interface{index, tracker.name()}, tracker.gatewayAddress());
             tracker.clearFlag(DirtyFlag::GatewayAddressChanged);
         }
-        if (m_macAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::EthernetAddressChanged))
+        if (m_macAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::MacAddressChanged))
         {
-            m_macAddressNotifier.notify(network::Interface{index, tracker.name()}, tracker.ethernetAddress());
-            tracker.clearFlag(DirtyFlag::EthernetAddressChanged);
+            m_macAddressNotifier.notify(network::Interface{index, tracker.name()}, tracker.macAddress());
+            tracker.clearFlag(DirtyFlag::MacAddressChanged);
         }
         if (m_broadcastAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::BroadcastAddressChanged))
         {

--- a/src/monkas/monitor/RtnlNetworkMonitor.cpp
+++ b/src/monkas/monitor/RtnlNetworkMonitor.cpp
@@ -452,15 +452,15 @@ void RtnlNetworkMonitor::parseLinkMessage(const nlmsghdr *nlhdr, const ifinfomsg
     {
         const auto *addr = static_cast<const uint8_t *>(mnl_attr_get_payload(attributes[IFLA_ADDRESS]));
         const auto len = mnl_attr_get_payload_len(attributes[IFLA_ADDRESS]);
-        auto ethernetAddress = ethernet::Address::fromBytes(addr, len);
-        cacheEntry.setMacAddress(ethernetAddress);
+        auto macAddress = ethernet::Address::fromBytes(addr, len);
+        cacheEntry.setMacAddress(macAddress);
     }
     if (attributes[IFLA_BROADCAST] != nullptr)
     {
         const auto *addr = static_cast<const uint8_t *>(mnl_attr_get_payload(attributes[IFLA_BROADCAST]));
         const auto len = mnl_attr_get_payload_len(attributes[IFLA_BROADCAST]);
-        auto ethernetAddress = ethernet::Address::fromBytes(addr, len);
-        cacheEntry.setBroadcastAddress(ethernetAddress);
+        auto broadcastAddress = ethernet::Address::fromBytes(addr, len);
+        cacheEntry.setBroadcastAddress(broadcastAddress);
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated all references from "Ethernet address" to "MAC address" throughout the user interface and log messages for consistency.
  - Renamed related options and notifications to use "MAC address" terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->