### PR TITLE
fix: Update Address comparison to use memcmp and handle IPv4-mapped IPv6 equivalence

### DIFF
--- a/src/monkas/ip/Address.test.cpp
+++ b/src/monkas/ip/Address.test.cpp
@@ -54,8 +54,9 @@ TEST_SUITE("[ip::Address]")
 
         std::array<uint8_t, 4> localhost4_other{127, 0, 1, 1};
         CHECK(Address::fromBytes(localhost4) < Address::fromBytes(localhost4_other));
-
         CHECK(Address::fromBytes(localhost4) < Address::fromBytes(localhost6));
+        CHECK_FALSE(Address::fromBytes(localhostV4mapped) < Address::fromBytes(localhost4));
+        CHECK_FALSE(Address::fromBytes(localhost4) < Address::fromBytes(localhostV4mapped));
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved address comparison logic to correctly handle IPv4 and IPv4-mapped IPv6 addresses, ensuring accurate equality and ordering checks.

- **Tests**
  - Enhanced test coverage for address comparisons, specifically verifying correct behavior when comparing IPv4 addresses with their IPv4-mapped IPv6 equivalents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->