### PR TITLE
feat: Expand Address classes with IP classification and conversion methods

### DIFF
--- a/include/monkas/ip/Address.hpp
+++ b/include/monkas/ip/Address.hpp
@@ -7,6 +7,7 @@
 #include <fmt/ostream.h>
 #include <iosfwd>
 #include <optional>
+#include <span>
 #include <string>
 
 namespace monkas::ip
@@ -89,6 +90,8 @@ class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
     [[nodiscard]] auto operator==(const Address &rhs) const noexcept -> bool;
 
   private:
+    [[nodiscard]] auto ipv4() const -> uint32_t;
+
     Family m_family{Family::Unspecified};
 };
 

--- a/include/monkas/ip/Address.hpp
+++ b/include/monkas/ip/Address.hpp
@@ -6,6 +6,7 @@
 #include <fmt/format.h>
 #include <fmt/ostream.h>
 #include <iosfwd>
+#include <optional>
 #include <string>
 
 namespace monkas::ip
@@ -55,7 +56,26 @@ class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
         return m_family == Family::Unspecified;
     }
 
+    [[nodiscard]] auto isMulticast() const -> bool;
+    [[nodiscard]] auto isLinkLocal() const -> bool;
+    [[nodiscard]] auto isUniqueLocal() const -> bool;
+    [[nodiscard]] auto isLoopback() const -> bool;
+    [[nodiscard]] auto isBroadcast() const -> bool;
+    [[nodiscard]] auto isPrivate() const -> bool;
+    [[nodiscard]] auto isDocumentation() const -> bool;
+
     [[nodiscard]] auto isMappedV4() const -> bool;
+    [[nodiscard]] auto toMappedV4() const -> std::optional<Address>;
+
+    [[nodiscard]] auto ip() const -> const Address &;
+    [[nodiscard]] auto broadcast() const -> const Address &;
+    [[nodiscard]] auto prefixLength() const -> uint8_t;
+    [[nodiscard]] auto scope() const -> uint8_t; // TODO: use Scope enum
+    [[nodiscard]] auto flags() const -> uint32_t;
+
+    [[nodiscard]] auto toBytes() const -> std::array<uint8_t, IPV6_ADDR_LEN>;
+    [[nodiscard]] auto toBytesV4() const -> std::array<uint8_t, IPV4_ADDR_LEN>;
+    [[nodiscard]] auto toBytesV6() const -> std::array<uint8_t, IPV6_ADDR_LEN>;
     [[nodiscard]] auto family() const -> Family;
     [[nodiscard]] auto addressLength() const -> size_type;
 

--- a/include/monkas/network/Address.hpp
+++ b/include/monkas/network/Address.hpp
@@ -31,6 +31,12 @@ class Address
     explicit operator bool() const;
 
     [[nodiscard]] auto family() const -> Family;
+
+    [[nodiscard]] auto isV4() const -> bool;
+    [[nodiscard]] auto isV6() const -> bool;
+    [[nodiscard]] auto isUnspecified() const -> bool;
+    [[nodiscard]] auto isMappedV4() const -> bool;
+
     [[nodiscard]] auto ip() const -> const ip::Address &;
     [[nodiscard]] auto broadcast() const -> const ip::Address &;
     [[nodiscard]] auto prefixLength() const -> uint8_t;

--- a/src/monkas/ip/Address.cpp
+++ b/src/monkas/ip/Address.cpp
@@ -58,6 +58,148 @@ Address::operator bool() const
     return m_family != Family::Unspecified;
 }
 
+auto Address::isMulticast() const -> bool
+{
+    if (m_family == Family::IPv4)
+    {
+        constexpr auto V4_MCAST_START = 224;
+        constexpr auto V4_MCAST_END = 239;
+        return data()[0] >= V4_MCAST_START && data()[0] <= V4_MCAST_END;
+    }
+    if (m_family == Family::IPv6)
+    {
+        constexpr auto V6_MCAST_PREFIX = 0xffU;
+        constexpr auto V6_MCAST_MASK = 0xf0U;
+        return data()[0] == V6_MCAST_PREFIX && (data()[1] & V6_MCAST_MASK) == 0x00;
+    }
+    return false;
+}
+
+auto Address::isLinkLocal() const -> bool
+{
+    if (m_family == Family::IPv4)
+    {
+        constexpr auto LINK_LOCAL_START = 169;
+        constexpr auto LINK_LOCAL_END = 254;
+        return data()[0] == LINK_LOCAL_START && data()[1] == LINK_LOCAL_END;
+    }
+    if (m_family == Family::IPv6)
+    {
+        constexpr auto V6_LL_PREFIX = 0xfeU;
+        constexpr auto V6_LL_MASK = 0xc0U;
+        constexpr auto V6_LL_BITS = 0x80U;
+        return data()[0] == V6_LL_PREFIX && (data()[1] & V6_LL_MASK) == V6_LL_BITS;
+    }
+    return false;
+}
+
+auto Address::isUniqueLocal() const -> bool
+{
+    if (m_family == Family::IPv6)
+    {
+        // Unique local IPv6 addresses are in fc00::/7 (first 7 bits are 1111 110)
+        // So, check if the first byte & 0xFE == 0xFC
+        constexpr auto V6_UL_PREFIX = 0xFCU;
+        constexpr auto V6_UL_MASK = 0xFEU;
+        return (data()[0] & V6_UL_MASK) == V6_UL_PREFIX;
+    }
+    return false;
+}
+
+auto Address::isLoopback() const -> bool
+{
+    // Loopback address in IPv4 is
+    constexpr uint8_t LOOPBACK_FIRST_OCTET = 127;
+    if (isV4())
+    {
+        return data()[0] == LOOPBACK_FIRST_OCTET;
+    }
+    if (isMappedV4())
+    {
+        return data()[V4_MAPPED_PREFIX.size()] == LOOPBACK_FIRST_OCTET;
+    }
+    if (isV6())
+    {
+        // Loopback address in IPv6 is ::1
+        return std::count(cbegin(), cend(), 0) == IPV6_ADDR_LEN - 1 && data()[IPV6_ADDR_LEN - 1] == 1;
+    }
+    return false;
+}
+
+auto Address::isBroadcast() const -> bool
+{
+    if (m_family == Family::IPv4)
+    {
+        constexpr uint8_t IPV4_BROADCAST_BYTE = 0xFF;
+        return std::all_of(cbegin(), cbegin() + addressLength(),
+                           [](uint8_t byte) { return byte == IPV4_BROADCAST_BYTE; });
+    }
+    return false;
+}
+
+auto Address::isPrivate() const -> bool
+{
+    // Private IPv4 ranges:
+    // 10.0.0.0/8:   10.0.0.0 - 10.255.255.255
+    // 172.16.0.0/12: 172.16.0.0 - 172.31.255.255
+    // 192.168.0.0/16: 192.168.0.0 - 192.168.255.255
+    constexpr uint32_t IPV4_10_0_0_0 = 0x0A000000;        // 10.0.0.0
+    constexpr uint32_t IPV4_10_255_255_255 = 0x0AFFFFFF;  // 10.255.255.255
+    constexpr uint32_t IPV4_172_16_0_0 = 0xAC100000;      // 172.16.0.0
+    constexpr uint32_t IPV4_172_31_255_255 = 0xAC1FFFFF;  // 172.31.255.255
+    constexpr uint32_t IPV4_192_168_0_0 = 0xC0A80000;     // 192.168.0.0
+    constexpr uint32_t IPV4_192_168_255_255 = 0xC0A8FFFF; // 192.168.255.255
+
+    if (isV4())
+    {
+        uint32_t addr = ntohl(*std::bit_cast<uint32_t *>(data()));
+        if ((addr >= IPV4_10_0_0_0 && addr <= IPV4_10_255_255_255) ||   // 10.0.0.0/8
+            (addr >= IPV4_172_16_0_0 && addr <= IPV4_172_31_255_255) || // 172.16.0.0/12
+            (addr >= IPV4_192_168_0_0 && addr <= IPV4_192_168_255_255)) // 192.168.0.0/16
+        {
+            return true;
+        }
+    }
+    if (isMappedV4())
+    {
+        // Check the mapped IPv4 address
+        uint32_t addr = ntohl(*std::bit_cast<uint32_t *>(data() + V4_MAPPED_PREFIX.size()));
+        if ((addr >= IPV4_10_0_0_0 && addr <= IPV4_10_255_255_255) ||   // 10.0.0.0/8
+            (addr >= IPV4_172_16_0_0 && addr <= IPV4_172_31_255_255) || // 172.16.0.0/12
+            (addr >= IPV4_192_168_0_0 && addr <= IPV4_192_168_255_255)) // 192.168.0.0/16
+        {
+            return true;
+        }
+    }
+    if (isV6())
+    {
+        return isUniqueLocal(); // Unique local addresses in IPv6 are considered private
+    }
+    return false;
+}
+
+auto Address::isDocumentation() const -> bool
+{
+    if (!isV4() && !isMappedV4())
+    {
+        return false; // Only IPv4 addresses can be documentation addresses
+    }
+
+    // Documentation IPv4 ranges according to RFC 5737:
+    // 192.0.2.0/24
+    // 198.51.100.0/24
+    // 203.0.113.0/24
+    static constexpr uint32_t DOC1_BASE = (192U << 24U) | (0U << 16U) | (2U << 8U);    // 192.0.2.0
+    static constexpr uint32_t DOC2_BASE = (198U << 24U) | (51U << 16U) | (100U << 8U); // 198.51.100.0
+    static constexpr uint32_t DOC3_BASE = (203U << 24U) | (0U << 16U) | (113U << 8U);  // 203.0.113.0
+    static constexpr uint32_t DOC_MASK = 0xFFFFFF00;                                   // /24 mask
+
+    // Assume Address has a method to get IPv4 as uint32_t in host byte order
+    uint32_t addr = ntohl(*std::bit_cast<uint32_t *>(isMappedV4() ? data() + V4_MAPPED_PREFIX.size() : data()));
+
+    return ((addr & DOC_MASK) == DOC1_BASE) || ((addr & DOC_MASK) == DOC2_BASE) || ((addr & DOC_MASK) == DOC3_BASE);
+}
+
 auto Address::family() const -> Family
 {
     return m_family;
@@ -83,6 +225,24 @@ auto Address::isMappedV4() const -> bool
         return std::memcmp(data(), V4_MAPPED_PREFIX.data(), V4_MAPPED_PREFIX.size()) == 0;
     }
     return false;
+}
+
+auto Address::toMappedV4() const -> std::optional<Address>
+{
+    if (isV4())
+    {
+        Address v6;
+        // Set the IPv4-mapped IPv6 prefix: ::ffff:0:0/96
+        constexpr size_t PREFIX_FF_INDEX_1 = 10;
+        constexpr size_t PREFIX_FF_INDEX_2 = 11;
+        constexpr uint8_t PREFIX_FF_VALUE = 0xff;
+        v6[PREFIX_FF_INDEX_1] = PREFIX_FF_VALUE;
+        v6[PREFIX_FF_INDEX_2] = PREFIX_FF_VALUE;
+        std::copy_n(data(), IPV4_ADDR_LEN, v6.begin() + V4_MAPPED_PREFIX.size());
+        v6.m_family = Family::IPv6;
+        return v6;
+    }
+    return std::nullopt;
 }
 
 auto Address::toString() const -> std::string

--- a/src/monkas/ip/Address.cpp
+++ b/src/monkas/ip/Address.cpp
@@ -4,8 +4,6 @@
 #include <algorithm>
 #include <arpa/inet.h>
 #include <ostream>
-#include <span>
-#include <type_traits>
 
 namespace monkas::ip
 {
@@ -125,7 +123,7 @@ auto Address::isLoopback() const -> bool
     if (isV6())
     {
         // Loopback address in IPv6 is ::1
-        return std::count(cbegin(), cend(), 0) == IPV6_ADDR_LEN - 1 && data()[IPV6_ADDR_LEN - 1] == 1;
+        return std::all_of(cbegin(), cend() - 1, [](uint8_t b) { return b == 0; }) && data()[IPV6_ADDR_LEN - 1] == 1;
     }
     return false;
 }

--- a/src/monkas/ip/Address.cpp
+++ b/src/monkas/ip/Address.cpp
@@ -233,12 +233,12 @@ auto Address::toMappedV4() const -> std::optional<Address>
     {
         Address v6;
         // Set the IPv4-mapped IPv6 prefix: ::ffff:0:0/96
-        constexpr size_t PREFIX_FF_INDEX_1 = 10;
-        constexpr size_t PREFIX_FF_INDEX_2 = 11;
-        constexpr uint8_t PREFIX_FF_VALUE = 0xff;
-        v6[PREFIX_FF_INDEX_1] = PREFIX_FF_VALUE;
-        v6[PREFIX_FF_INDEX_2] = PREFIX_FF_VALUE;
-        std::copy_n(data(), IPV4_ADDR_LEN, v6.begin() + V4_MAPPED_PREFIX.size());
+        std::copy(V4_MAPPED_PREFIX.begin(),
+                  V4_MAPPED_PREFIX.end(),
+                  v6.begin());
+        std::copy_n(data(),
+                    IPV4_ADDR_LEN,
+                    v6.begin() + V4_MAPPED_PREFIX.size());
         v6.m_family = Family::IPv6;
         return v6;
     }

--- a/src/monkas/ip/Address.test.cpp
+++ b/src/monkas/ip/Address.test.cpp
@@ -68,6 +68,12 @@ TEST_SUITE("[ip::Address]")
         CHECK(!localHost6.isMappedV4());
     }
 
+    TEST_CASE("toMappedV4")
+    {
+        CHECK(localhost4.toMappedV4() == localhost4);
+        CHECK(!localHost6.toMappedV4());
+    }
+
     TEST_CASE("isV4")
     {
         CHECK(localhost4.isV4());
@@ -90,6 +96,78 @@ TEST_SUITE("[ip::Address]")
         CHECK(!localhostV4mapped.isUnspecified());
     }
 
+    TEST_CASE("isMulticast")
+    {
+        CHECK(Address::fromString("224.0.0.1").isMulticast());
+        CHECK(Address::fromString("239.255.255.253").isMulticast());
+        CHECK(Address::fromString("ff02::1").isMulticast());
+        CHECK(Address::fromString("ff02::2").isMulticast());
+        CHECK(Address::fromString("ff02::3").isMulticast());
+        CHECK(Address::fromString("ff02::4").isMulticast());
+        CHECK(!unspec.isMulticast());
+        CHECK(!localhost4.isMulticast());
+        CHECK(!localHost6.isMulticast());
+        CHECK(!localhostV4mapped.isMulticast());
+        CHECK(!any4.isMulticast());
+        CHECK(!any6.isMulticast());
+    }
+
+    TEST_CASE("isLinkLocal")
+    {
+        CHECK(Address::fromString("169.254.0.1").isLinkLocal());
+        CHECK(Address::fromString("169.254.255.255").isLinkLocal());
+        CHECK(Address::fromString("fe80::1").isLinkLocal());
+        CHECK(Address::fromString("fe80::2").isLinkLocal());
+        CHECK(Address::fromString("fe80::3").isLinkLocal());
+        CHECK(!unspec.isLinkLocal());
+        CHECK(!localhost4.isLinkLocal());
+        CHECK(!localHost6.isLinkLocal());
+        CHECK(!localhostV4mapped.isLinkLocal());
+        CHECK(!any4.isLinkLocal());
+        CHECK(!any6.isLinkLocal());
+    }
+
+    TEST_CASE("isUniqueLocal")
+    {
+        CHECK(Address::fromString("fc00::1").isUniqueLocal());
+        CHECK(Address::fromString("fd00::1").isUniqueLocal());
+        CHECK(Address::fromString("fc00:1234:5678:9abc:def0:1234:5678:9abc").isUniqueLocal());
+        CHECK(!unspec.isUniqueLocal());
+        CHECK(!localhost4.isUniqueLocal());
+        CHECK(!localHost6.isUniqueLocal());
+        CHECK(!localhostV4mapped.isUniqueLocal());
+        CHECK(!any4.isUniqueLocal());
+        CHECK(!any6.isUniqueLocal());
+    }
+
+    TEST_CASE("isBroadcast")
+    {
+        CHECK(Address::fromString("255.255.255.255").isBroadcast());
+    }
+
+    TEST_CASE("isLoopback")
+    {
+        CHECK(localhost4.isLoopback());
+        CHECK(localHost6.isLoopback());
+        CHECK(localhostV4mapped.isLoopback());
+        CHECK(Address::fromString("127.253.253.123").isLoopback());
+    }
+
+    TEST_CASE("isPrivate")
+    {
+        CHECK(Address::fromString("192.168.0.1").isPrivate());
+        CHECK(Address::fromString("172.16.0.1").isPrivate());
+        CHECK(Address::fromString("10.0.0.1").isPrivate());
+        CHECK(Address::fromString("10.0.0.1").toMappedV4().value().isPrivate());
+    }
+
+    TEST_CASE("isDocumentation")
+    {
+        CHECK(Address::fromString("192.0.2.1").isDocumentation());
+        CHECK(Address::fromString("198.51.100.1").isDocumentation());
+        CHECK(Address::fromString("203.0.113.1").isDocumentation());
+        CHECK(Address::fromString("203.0.113.1").toMappedV4().value().isDocumentation());
+    }
     TEST_CASE("operator bool")
     {
         CHECK(!unspec);

--- a/src/monkas/ip/Address.test.cpp
+++ b/src/monkas/ip/Address.test.cpp
@@ -143,6 +143,11 @@ TEST_SUITE("[ip::Address]")
     TEST_CASE("isBroadcast")
     {
         CHECK(Address::fromString("255.255.255.255").isBroadcast());
+        CHECK(!Address::fromString("192.168.1.1").isBroadcast());
+        CHECK(!localhost4.isBroadcast());
+        CHECK(!localHost6.isBroadcast());
+        CHECK(!any4.isBroadcast());
+        CHECK(!any6.isBroadcast());
     }
 
     TEST_CASE("isLoopback")

--- a/src/monkas/network/Address.cpp
+++ b/src/monkas/network/Address.cpp
@@ -25,6 +25,26 @@ auto Address::family() const -> Family
     return m_ip.family();
 }
 
+auto Address::isV4() const -> bool
+{
+    return m_ip.isV4();
+}
+
+auto Address::isV6() const -> bool
+{
+    return m_ip.isV6();
+}
+
+auto Address::isUnspecified() const -> bool
+{
+    return m_ip.isUnspecified();
+}
+
+auto Address::isMappedV4() const -> bool
+{
+    return m_ip.isMappedV4();
+}
+
 auto Address::ip() const -> const ip::Address &
 {
     return m_ip;

--- a/src/monkas/network/Address.test.cpp
+++ b/src/monkas/network/Address.test.cpp
@@ -34,6 +34,32 @@ TEST_SUITE("[network::Address]")
         CHECK(defaultAddress.family() == network::Family::Unspecified);
     }
 
+    TEST_CASE("isV4")
+    {
+        CHECK(addr.isV4());
+        CHECK(!addr.isV6());
+        CHECK(defaultAddress.isUnspecified());
+    }
+
+    TEST_CASE("isV6")
+    {
+        CHECK(!addr.isV6());
+        CHECK(addr.isV4());
+        CHECK(defaultAddress.isUnspecified());
+    }
+
+    TEST_CASE("isUnspecified")
+    {
+        CHECK(defaultAddress.isUnspecified());
+        CHECK(!addr.isUnspecified());
+    }
+
+    TEST_CASE("isMappedV4")
+    {
+        CHECK(!addr.isMappedV4());
+        CHECK(!defaultAddress.isMappedV4());
+    }
+
     TEST_CASE("ip")
     {
         CHECK(addr.ip() == someV4);

--- a/src/monkas/network/Address.test.cpp
+++ b/src/monkas/network/Address.test.cpp
@@ -19,97 +19,99 @@ TEST_SUITE("[network::Address]")
 
     const auto someV4 = ip::Address::fromBytes(some_ipv4);
     const auto someBcastV4 = ip::Address::fromBytes(some_bcast);
-    const Address addr{someV4, someBcastV4, 24, scope, 10};
+    const auto someV6 = ip::Address::fromString("2001:db8::1");
+    const Address addrV6{someV6, someBcastV4, 24, scope, 5};
+    const Address addrV4{someV4, someBcastV4, 24, scope, 10};
     const Address defaultAddress{};
 
     TEST_CASE("operator bool")
     {
-        CHECK(addr);
+        CHECK(addrV4);
         CHECK(!defaultAddress);
     }
 
     TEST_CASE("family")
     {
-        CHECK(addr.family() == someV4.family());
+        CHECK(addrV4.family() == someV4.family());
         CHECK(defaultAddress.family() == network::Family::Unspecified);
     }
 
     TEST_CASE("isV4")
     {
-        CHECK(addr.isV4());
-        CHECK(!addr.isV6());
-        CHECK(defaultAddress.isUnspecified());
+        CHECK(addrV4.isV4());
+        CHECK(!defaultAddress.isV4());
     }
 
     TEST_CASE("isV6")
     {
-        CHECK(!addr.isV6());
-        CHECK(addr.isV4());
-        CHECK(defaultAddress.isUnspecified());
+        CHECK(!addrV4.isV6());
+        CHECK(addrV6.isV6());
+        CHECK(!defaultAddress.isV6());
     }
 
     TEST_CASE("isUnspecified")
     {
         CHECK(defaultAddress.isUnspecified());
-        CHECK(!addr.isUnspecified());
+        CHECK(!addrV6.isUnspecified());
+        CHECK(!addrV4.isUnspecified());
     }
 
     TEST_CASE("isMappedV4")
     {
-        CHECK(!addr.isMappedV4());
+        CHECK(!addrV4.isMappedV4());
         CHECK(!defaultAddress.isMappedV4());
     }
 
     TEST_CASE("ip")
     {
-        CHECK(addr.ip() == someV4);
+        CHECK(addrV4.ip() == someV4);
         CHECK(defaultAddress.ip() == ip::Address{});
     }
 
     TEST_CASE("broadcast")
     {
-        CHECK(addr.broadcast() == someBcastV4);
+        CHECK(addrV4.broadcast() == someBcastV4);
         CHECK(defaultAddress.broadcast() == ip::Address{});
     }
 
     TEST_CASE("prefixLength")
     {
-        CHECK(addr.prefixLength() == 24);
+        CHECK(addrV4.prefixLength() == 24);
         CHECK(defaultAddress.prefixLength() == 0);
     }
 
     TEST_CASE("scope")
     {
-        CHECK(addr.scope() == scope);
+        CHECK(addrV4.scope() == scope);
         CHECK(defaultAddress.scope() == network::Scope::Nowhere);
     }
 
     TEST_CASE("flags")
     {
-        CHECK(addr.flags() == 10);
+        CHECK(addrV4.flags() == 10);
         CHECK(defaultAddress.flags() == 0);
     }
 
     TEST_CASE("operator ==")
     {
         CHECK(defaultAddress == defaultAddress);
-        CHECK(addr == addr);
+        CHECK(addrV4 == addrV4);
     }
 
     TEST_CASE("operator !=")
     {
-        CHECK(defaultAddress != addr);
+        CHECK(defaultAddress != addrV4);
     }
 
     TEST_CASE("operator <")
     {
-        CHECK(defaultAddress < addr);
-        CHECK(addr >= defaultAddress);
+        CHECK(defaultAddress < addrV4);
+        CHECK(addrV4 >= defaultAddress);
     }
 
     TEST_CASE("operator >=")
     {
-        CHECK(addr >= defaultAddress);
+        CHECK(addrV4 >= defaultAddress);
     }
 }
 


### PR DESCRIPTION
Closes #73 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new methods to classify IP addresses, including multicast, link-local, unique local, loopback, broadcast, private, and documentation types.
  - Introduced conversion to IPv6-mapped IPv4 addresses and new accessors for address properties and byte representations.
  - Added functions to determine if an address is IPv4, IPv6, unspecified, or an IPv4-mapped IPv6 address.

- **Tests**
  - Expanded test coverage for all new address classification and conversion methods to ensure correct behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->