### PR TITLE
chore: Process all link messages in parseLinkMessage regardless of interface type

### DIFF
--- a/src/monkas/monitor/RtnlNetworkMonitor.cpp
+++ b/src/monkas/monitor/RtnlNetworkMonitor.cpp
@@ -409,11 +409,11 @@ void RtnlNetworkMonitor::parseLinkMessage(const nlmsghdr *nlhdr, const ifinfomsg
 {
     m_stats.linkMessagesSeen++;
     // TODO ifi_type filters
-    if (ifi->ifi_type != ARPHRD_ETHER)
-    {
-        m_stats.msgsDiscarded++;
-        return;
-    }
+    // if (ifi->ifi_type != ARPHRD_ETHER)
+    // {
+    //     m_stats.msgsDiscarded++;
+    //     return;
+    // }
     if (nlhdr->nlmsg_type == RTM_DELLINK)
     {
         spdlog::trace("removing interface with index {}", ifi->ifi_index);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated network monitoring to process all link messages, regardless of interface type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->