### PR TITLE
chore: Fix Dockerfile metadata labels to use correct lowercase "monkas" spelling

### DIFF
--- a/.github/docker/monkas-github-gcc/Dockerfile
+++ b/.github/docker/monkas-github-gcc/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && \
     ninja-build \
     && rm -rf /var/lib/apt/lists/*
 
-LABEL org.opencontainers.image.source="https://github.com/hrzlgnm/monkaS"
-LABEL org.opencontainers.image.title="monkaS GitHub GCC"
+LABEL org.opencontainers.image.source="https://github.com/hrzlgnm/monkas"
+LABEL org.opencontainers.image.title="monkas GitHub GCC"
 LABEL org.opencontainers.image.base.name="docker.io/library/gcc"
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated image metadata labels to correct URL and title casing in the Dockerfile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->