### PR TITLE
chore(ci): Add SCCACHE_GHA_ENABLED env variable to Non-Default-Build-Config CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,8 @@ jobs:
 
   Non-Default-Build-Config:
     runs-on: ubuntu-latest
+    env:
+      SCCACHE_GHA_ENABLED: true
     container:
       image: ghcr.io/hrzlgnm/monkas-github-gcc:v1@sha256:1c484f72754e77c7b250005e26e468aa1c7c7765487e3f2e9a2fc6edcf19e82d
     steps:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated CI workflow configuration to enable a specific environment variable for improved consistency across jobs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->