### PR TITLE
refactor: Extract different Address types directly from Attributes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -162,4 +162,4 @@ jobs:
 
       - name: CLI example nerdstats/dumppackets
         run: |
-          ../build/examples/cli/monka --log-level=trace --nerdstats --dumppackets --exit-after-enumeration
+          ../build/examples/cli/monka --log-level=trace --nerdstats --dumppackets --include_non_ieee802 --exit-after-enumeration

--- a/include/monkas/monitor/Attributes.hpp
+++ b/include/monkas/monitor/Attributes.hpp
@@ -2,6 +2,8 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <ethernet/Address.hpp>
+#include <ip/Address.hpp>
 #include <libmnl/libmnl.h>
 #include <optional>
 #include <spdlog/spdlog.h>
@@ -27,6 +29,9 @@ class Attributes
     [[nodiscard]] auto getU16(uint16_t type) const -> std::optional<uint16_t>;
     [[nodiscard]] auto getU32(uint16_t type) const -> std::optional<uint32_t>;
     [[nodiscard]] auto getU64(uint16_t type) const -> std::optional<uint64_t>;
+    [[nodiscard]] auto getEthernetAddress(uint16_t type) const -> std::optional<ethernet::Address>;
+    [[nodiscard]] auto getIpV4Address(uint16_t type) const -> std::optional<ip::Address>;
+    [[nodiscard]] auto getIpV6Address(uint16_t type) const -> std::optional<ip::Address>;
 
     template <std::size_t N> [[nodiscard]] auto getPayload(uint16_t type) const -> std::optional<std::array<uint8_t, N>>
     {

--- a/include/monkas/monitor/Attributes.hpp
+++ b/include/monkas/monitor/Attributes.hpp
@@ -33,25 +33,6 @@ class Attributes
     [[nodiscard]] auto getIpV4Address(uint16_t type) const -> std::optional<ip::Address>;
     [[nodiscard]] auto getIpV6Address(uint16_t type) const -> std::optional<ip::Address>;
 
-    template <std::size_t N> [[nodiscard]] auto getPayload(uint16_t type) const -> std::optional<std::array<uint8_t, N>>
-    {
-        if (!has(type))
-        {
-            return std::nullopt;
-        }
-
-        if (mnl_attr_validate2(m_attributes[type], MNL_TYPE_UNSPEC, N) < 0)
-        {
-            spdlog::trace("payload of type {} has len {} != {}", type, mnl_attr_get_payload_len(m_attributes[type]), N);
-            return std::nullopt;
-        }
-
-        const auto *payload = static_cast<const uint8_t *>(mnl_attr_get_payload(m_attributes[type]));
-        std::array<uint8_t, N> arr;
-        std::copy_n(payload, N, arr.data());
-        return arr;
-    }
-
   private:
     explicit Attributes(std::size_t toAlloc);
 
@@ -69,6 +50,25 @@ class Attributes
             return std::nullopt;
         }
         return getter(m_attributes[type]);
+    }
+
+    template <std::size_t N> [[nodiscard]] auto getPayload(uint16_t type) const -> std::optional<std::array<uint8_t, N>>
+    {
+        if (!has(type))
+        {
+            return std::nullopt;
+        }
+
+        if (mnl_attr_validate2(m_attributes[type], MNL_TYPE_UNSPEC, N) < 0)
+        {
+            spdlog::trace("payload of type {} has len {} != {}", type, mnl_attr_get_payload_len(m_attributes[type]), N);
+            return std::nullopt;
+        }
+
+        const auto *payload = static_cast<const uint8_t *>(mnl_attr_get_payload(m_attributes[type]));
+        std::array<uint8_t, N> arr;
+        std::copy_n(payload, N, arr.data());
+        return arr;
     }
 
     struct CallbackArgs

--- a/src/monitor/Attributes.cpp
+++ b/src/monitor/Attributes.cpp
@@ -1,4 +1,3 @@
-#include "ethernet/Address.hpp"
 #include <libmnl/libmnl.h>
 #include <monitor/Attributes.hpp>
 #include <spdlog/spdlog.h>

--- a/src/monitor/Attributes.cpp
+++ b/src/monitor/Attributes.cpp
@@ -1,3 +1,4 @@
+#include "ethernet/Address.hpp"
 #include <libmnl/libmnl.h>
 #include <monitor/Attributes.hpp>
 #include <spdlog/spdlog.h>
@@ -72,4 +73,19 @@ auto Attributes::getU64(uint16_t type) const -> std::optional<uint64_t>
     return getTypedAttribute<uint64_t>(type, MNL_TYPE_U64, mnl_attr_get_u64);
 }
 
+auto Attributes::getEthernetAddress(uint16_t type) const -> std::optional<ethernet::Address>
+{
+    return getPayload<ethernet::ADDR_LEN>(type).transform(
+        [](const auto &arr) { return ethernet::Address::fromBytes(arr); });
+}
+
+auto Attributes::getIpV6Address(uint16_t type) const -> std::optional<ip::Address>
+{
+    return getPayload<ip::IPV6_ADDR_LEN>(type).transform([](const auto &arr) { return ip::Address::fromBytes(arr); });
+}
+
+auto Attributes::getIpV4Address(uint16_t type) const -> std::optional<ip::Address>
+{
+    return getPayload<ip::IPV4_ADDR_LEN>(type).transform([](const auto &arr) { return ip::Address::fromBytes(arr); });
+}
 } // namespace monkas::monitor


### PR DESCRIPTION
Closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new methods for extracting Ethernet, IPv4, and IPv6 addresses as typed objects, improving how network addresses are retrieved and handled.

- **Refactor**
  - Updated address extraction in the network monitor to use new helper methods, resulting in clearer and more robust address handling.

- **Chores**
  - Updated CI workflow to include additional command-line flag for broader packet inclusion during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->