### PR TITLE
chore(style): Steal clang format from cappuchin

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,192 +1,178 @@
 ---
 Language: Cpp
-# BasedOnStyle:  Microsoft
+# BasedOnStyle: Chromium
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignArrayOfStructures: None
-AlignConsecutiveMacros: None
-AlignConsecutiveAssignments: None
-AlignConsecutiveBitFields: None
-AlignConsecutiveDeclarations: None
-AlignEscapedNewlines: Right
-AlignOperands: Align
-AlignTrailingComments: true
+AlignConsecutiveMacros: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveBitFields: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: DontAlign
+AlignOperands: DontAlign
+AlignTrailingComments: false
 AllowAllArgumentsOnNextLine: true
+AllowAllConstructorInitializersOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortEnumsOnASingleLine: false
-AllowShortBlocksOnASingleLine: Never
+AllowShortBlocksOnASingleLine: Empty
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: None
+AllowShortFunctionsOnASingleLine: Inline
 AllowShortLambdasOnASingleLine: All
 AllowShortIfStatementsOnASingleLine: Never
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
-AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: MultiLine
-AttributeMacros:
-  - __capability
-BinPackArguments: true
-BinPackParameters: true
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
 BraceWrapping:
-  AfterCaseLabel: false
-  AfterClass: true
-  AfterControlStatement: Always
-  AfterEnum: true
-  AfterFunction: true
-  AfterNamespace: true
-  AfterObjCDeclaration: true
-  AfterStruct: true
-  AfterUnion: false
-  AfterExternBlock: true
-  BeforeCatch: true
-  BeforeElse: true
-  BeforeLambdaBody: false
-  BeforeWhile: false
-  IndentBraces: false
-  SplitEmptyFunction: true
-  SplitEmptyRecord: true
-  SplitEmptyNamespace: true
-BreakBeforeBinaryOperators: None
-BreakBeforeConceptDeclarations: true
+    AfterCaseLabel: false
+    AfterClass: true
+    AfterControlStatement: MultiLine
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterObjCDeclaration: false
+    AfterStruct: true
+    AfterUnion: true
+    AfterExternBlock: true
+    BeforeCatch: false
+    BeforeElse: false
+    BeforeLambdaBody: true
+    BeforeWhile: false
+    IndentBraces: false
+    SplitEmptyFunction: true
+    SplitEmptyRecord: true
+    SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: NonAssignment
 BreakBeforeBraces: Custom
-BreakBeforeInheritanceComma: false
-BreakInheritanceList: BeforeColon
+# BreakBeforeInheritanceComma: true
+BreakInheritanceList: BeforeComma
 BreakBeforeTernaryOperators: true
-BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializersBeforeComma: true
 BreakConstructorInitializers: BeforeComma
-BreakAfterJavaFieldAnnotations: false
+BreakAfterJavaFieldAnnotations: true
 BreakStringLiterals: true
 ColumnLimit: 120
-CommentPragmas: "^ IWYU pragma:"
-QualifierAlignment: Leave
+CommentPragmas: '^ IWYU pragma:'
 CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DeriveLineEnding: true
+DeriveLineEnding: false
 DerivePointerAlignment: false
 DisableFormat: false
-EmptyLineAfterAccessModifier: Never
-EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
-PackConstructorInitializers: BinPack
-BasedOnStyle: Microsoft
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
-AllowAllConstructorInitializersOnNextLine: true
 FixNamespaceComments: true
 ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
-IfMacros:
-  - KJ_IF_MAYBE
-IncludeBlocks: Preserve
+    - foreach
+    - Q_FOREACH
+    - BOOST_FOREACH
+IncludeBlocks: Regroup
 IncludeCategories:
-  - Regex: '^"(llvm|llvm-c|clang|clang-c)/'
-    Priority: 2
-    SortPriority: 0
-    CaseSensitive: false
-  - Regex: '^(<|"(gtest|gmock|isl|json)/)'
-    Priority: 3
-    SortPriority: 0
-    CaseSensitive: false
-  - Regex: ".*"
-    Priority: 1
-    SortPriority: 0
-    CaseSensitive: false
-IncludeIsMainRegex: "(Test)?$"
-IncludeIsMainSourceRegex: ""
-IndentAccessModifiers: false
-IndentCaseLabels: false
+    # Standard library headers come before anything else
+    - Regex: '^<[a-z_]+>'
+      Priority: -1
+    - Regex: '^<.+\.h(pp)?>'
+      Priority: 1
+    - Regex: '^<.*'
+      Priority: 2
+    - Regex: '.*'
+      Priority: 3
+IncludeIsMainRegex: ''
+IncludeIsMainSourceRegex: ''
+IndentCaseLabels: true
 IndentCaseBlocks: false
 IndentGotoLabels: true
-IndentPPDirectives: None
-IndentExternBlock: AfterExternBlock
-IndentRequires: false
+IndentPPDirectives: AfterHash
+IndentExternBlock: NoIndent
 IndentWidth: 4
 IndentWrappedFunctionNames: false
-InsertTrailingCommas: None
-JavaScriptQuotes: Leave
+InsertTrailingCommas: Wrapped
+JavaScriptQuotes: Double
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
-LambdaBodyIndentation: Signature
-MacroBlockBegin: ""
-MacroBlockEnd: ""
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
-ObjCBinPackProtocolList: Auto
+ObjCBinPackProtocolList: Never
 ObjCBlockIndentWidth: 2
 ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: false
 ObjCSpaceBeforeProtocolList: true
 PenaltyBreakAssignment: 2
-PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakBeforeFirstCallParameter: 1
 PenaltyBreakComment: 300
 PenaltyBreakFirstLessLess: 120
-PenaltyBreakOpenParenthesis: 0
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
-PenaltyReturnTypeOnItsOwnLine: 1000
-PenaltyIndentedWhitespace: 0
-PointerAlignment: Right
-PPIndentWidth: -1
-ReferenceAlignment: Pointer
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+RawStringFormats:
+    - Language: Cpp
+      Delimiters:
+          - cc
+          - CC
+          - cpp
+          - Cpp
+          - CPP
+          - 'c++'
+          - 'C++'
+      CanonicalDelimiter: ''
+      BasedOnStyle: google
+    - Language: TextProto
+      Delimiters:
+          - pb
+          - PB
+          - proto
+          - PROTO
+      EnclosingFunctions:
+          - EqualsProto
+          - EquivToProto
+          - PARSE_PARTIAL_TEXT_PROTO
+          - PARSE_TEST_PROTO
+          - PARSE_TEXT_PROTO
+          - ParseTextOrDie
+          - ParseTextProtoOrDie
+          - ParseTestProto
+          - ParsePartialTestProto
+      CanonicalDelimiter: ''
+      BasedOnStyle: google
 ReflowComments: true
-RemoveBracesLLVM: false
 SeparateDefinitionBlocks: Always
-ShortNamespaceLines: 1
-SortIncludes: CaseInsensitive
-SortJavaStaticImport: Before
+SortIncludes: true
 SortUsingDeclarations: true
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
-SpaceAfterTemplateKeyword: true
+SpaceAfterTemplateKeyword: false
 SpaceBeforeAssignmentOperators: true
-SpaceBeforeCaseColon: false
-SpaceBeforeCpp11BracedList: false
+SpaceBeforeCpp11BracedList: true
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
-SpaceBeforeParens: ControlStatements
-SpaceBeforeParensOptions:
-  AfterControlStatements: true
-  AfterForeachMacros: true
-  AfterFunctionDefinitionName: false
-  AfterFunctionDeclarationName: false
-  AfterIfMacros: true
-  AfterOverloadedOperator: false
-  BeforeNonEmptyParentheses: false
-SpaceAroundPointerQualifiers: Default
+SpaceBeforeParens: ControlStatementsExceptForEachMacros
 SpaceBeforeRangeBasedForLoopColon: true
 SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
-SpacesBeforeTrailingComments: 1
-SpacesInAngles: Never
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
 SpacesInConditionalStatement: false
-SpacesInContainerLiterals: true
+SpacesInContainerLiterals: false
 SpacesInCStyleCastParentheses: false
-SpacesInLineCommentPrefix:
-  Minimum: 1
-  Maximum: -1
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 SpaceBeforeSquareBrackets: false
-BitFieldColonSpacing: Both
-Standard: Latest
-StatementAttributeLikeMacros:
-  - Q_EMIT
+Standard: Auto
 StatementMacros:
-  - Q_UNUSED
-  - QT_REQUIRE_VERSION
-TabWidth: 4
+    - Q_UNUSED
+    - QT_REQUIRE_VERSION
+TabWidth: 8
 UseCRLF: false
 UseTab: Never
 WhitespaceSensitiveMacros:
-  - STRINGIZE
-  - PP_STRINGIZE
-  - BOOST_PP_STRINGIZE
-  - NS_SWIFT_NAME
-  - CF_SWIFT_NAME
----
-
+    - STRINGIZE
+    - PP_STRINGIZE
+    - BOOST_PP_STRINGIZE

--- a/external/doctest/main.cpp
+++ b/external/doctest/main.cpp
@@ -1,7 +1,7 @@
 #define DOCTEST_CONFIG_IMPLEMENTATION_IN_DLL
 #include <doctest/doctest.h>
 
-auto main(int argc, char **argv) -> int
+auto main(int argc, char** argv) -> int
 {
     doctest::Context context;
 

--- a/include/monkas/ethernet/Address.hpp
+++ b/include/monkas/ethernet/Address.hpp
@@ -3,8 +3,9 @@
 #include <array>
 #include <compare>
 #include <cstdint>
-#include <fmt/ostream.h>
 #include <iosfwd>
+
+#include <fmt/ostream.h>
 
 namespace monkas::ethernet
 {
@@ -21,20 +22,21 @@ class Address : public std::array<uint8_t, ADDR_LEN>
      */
     explicit operator bool() const;
 
-    static auto fromBytes(const uint8_t *bytes, size_type len) -> Address;
-    static auto fromBytes(const std::array<uint8_t, ADDR_LEN> &bytes) -> Address;
+    static auto fromBytes(const uint8_t* bytes, size_type len) -> Address;
+    static auto fromBytes(const std::array<uint8_t, ADDR_LEN>& bytes) -> Address;
 
-    [[nodiscard]] auto operator<=>(const Address &) const -> std::strong_ordering;
-    [[nodiscard]] auto operator==(const Address &) const -> bool;
+    [[nodiscard]] auto operator<=>(const Address&) const -> std::strong_ordering;
+    [[nodiscard]] auto operator==(const Address&) const -> bool;
 
   private:
-    bool m_isValid{false};
+    bool m_isValid {false};
 };
 
-auto operator<<(std::ostream &o, const Address &a) -> std::ostream &;
+auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;
 
-} // namespace monkas::ethernet
+}  // namespace monkas::ethernet
 
-template <> struct fmt::formatter<monkas::ethernet::Address> : fmt::ostream_formatter
+template<>
+struct fmt::formatter<monkas::ethernet::Address> : fmt::ostream_formatter
 {
 };

--- a/include/monkas/ip/Address.hpp
+++ b/include/monkas/ip/Address.hpp
@@ -3,11 +3,12 @@
 #include <array>
 #include <compare>
 #include <cstdint>
-#include <fmt/format.h>
-#include <fmt/ostream.h>
 #include <iosfwd>
 #include <optional>
 #include <string>
+
+#include <fmt/format.h>
+#include <fmt/ostream.h>
 
 namespace monkas::ip
 {
@@ -20,7 +21,7 @@ enum class Family : uint8_t
 };
 
 auto asLinuxAf(Family f) -> int;
-auto operator<<(std::ostream &o, Family a) -> std::ostream &;
+auto operator<<(std::ostream& o, Family a) -> std::ostream&;
 
 constexpr auto IPV6_ADDR_LEN = 16;
 constexpr auto IPV4_ADDR_LEN = 4;
@@ -35,26 +36,17 @@ class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
      * Creates an Address from a string representation.
      * If the string is not a valid address, it returns an unspecified Address.
      */
-    static auto fromString(const std::string &address) -> Address;
+    static auto fromString(const std::string& address) -> Address;
     /**
      * @returns true if address is not unspecified
      */
     explicit operator bool() const;
 
-    [[nodiscard]] auto isV4() const -> bool
-    {
-        return m_family == Family::IPv4;
-    }
+    [[nodiscard]] auto isV4() const -> bool { return m_family == Family::IPv4; }
 
-    [[nodiscard]] auto isV6() const -> bool
-    {
-        return m_family == Family::IPv6;
-    }
+    [[nodiscard]] auto isV6() const -> bool { return m_family == Family::IPv6; }
 
-    [[nodiscard]] auto isUnspecified() const -> bool
-    {
-        return m_family == Family::Unspecified;
-    }
+    [[nodiscard]] auto isUnspecified() const -> bool { return m_family == Family::Unspecified; }
 
     [[nodiscard]] auto isMulticast() const -> bool;
     [[nodiscard]] auto isLinkLocal() const -> bool;
@@ -67,34 +59,35 @@ class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
     [[nodiscard]] auto isMappedV4() const -> bool;
     [[nodiscard]] auto toMappedV4() const -> std::optional<Address>;
 
-    [[nodiscard]] auto ip() const -> const Address &;
-    [[nodiscard]] auto broadcast() const -> const Address &;
+    [[nodiscard]] auto ip() const -> const Address&;
+    [[nodiscard]] auto broadcast() const -> const Address&;
     [[nodiscard]] auto prefixLength() const -> uint8_t;
-    [[nodiscard]] auto scope() const -> uint8_t; // TODO: use Scope enum
+    [[nodiscard]] auto scope() const -> uint8_t;  // TODO: use Scope enum
     [[nodiscard]] auto flags() const -> uint32_t;
 
     [[nodiscard]] auto family() const -> Family;
     [[nodiscard]] auto addressLength() const -> size_type;
 
-    static auto fromBytes(const uint8_t *bytes, size_type len) -> Address;
-    static auto fromBytes(const std::array<uint8_t, IPV4_ADDR_LEN> &bytes) -> Address;
-    static auto fromBytes(const std::array<uint8_t, IPV6_ADDR_LEN> &bytes) -> Address;
+    static auto fromBytes(const uint8_t* bytes, size_type len) -> Address;
+    static auto fromBytes(const std::array<uint8_t, IPV4_ADDR_LEN>& bytes) -> Address;
+    static auto fromBytes(const std::array<uint8_t, IPV6_ADDR_LEN>& bytes) -> Address;
 
     // overload the one from std::array<uint8_t, IPV6_ADDR_LEN>
-    [[nodiscard]] auto operator<=>(const Address &rhs) const noexcept -> std::strong_ordering;
+    [[nodiscard]] auto operator<=>(const Address& rhs) const noexcept -> std::strong_ordering;
     // overload the one from std::array<uint8_t, IPV6_ADDR_LEN>
-    [[nodiscard]] auto operator==(const Address &rhs) const noexcept -> bool;
+    [[nodiscard]] auto operator==(const Address& rhs) const noexcept -> bool;
 
   private:
     [[nodiscard]] auto ipv4() const -> uint32_t;
 
-    Family m_family{Family::Unspecified};
+    Family m_family {Family::Unspecified};
 };
 
-auto operator<<(std::ostream &o, const Address &a) -> std::ostream &;
+auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;
 
-} // namespace monkas::ip
+}  // namespace monkas::ip
 
-template <> struct fmt::formatter<monkas::ip::Address> : fmt::ostream_formatter
+template<>
+struct fmt::formatter<monkas::ip::Address> : fmt::ostream_formatter
 {
 };

--- a/include/monkas/monitor/Attributes.hpp
+++ b/include/monkas/monitor/Attributes.hpp
@@ -2,12 +2,13 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <optional>
+#include <vector>
+
 #include <ethernet/Address.hpp>
 #include <ip/Address.hpp>
 #include <libmnl/libmnl.h>
-#include <optional>
 #include <spdlog/spdlog.h>
-#include <vector>
 
 namespace monkas::monitor
 {
@@ -15,13 +16,13 @@ namespace monkas::monitor
 class Attributes
 {
   public:
-    static auto parse(const nlmsghdr *n, size_t offset, uint16_t maxType, uint64_t &counter) -> Attributes;
+    static auto parse(const nlmsghdr* n, size_t offset, uint16_t maxType, uint64_t& counter) -> Attributes;
 
     ~Attributes() = default;
-    Attributes(const Attributes &) = default;
-    Attributes(Attributes &&) = default;
-    auto operator=(const Attributes &) -> Attributes & = default;
-    auto operator=(Attributes &&) -> Attributes & = default;
+    Attributes(const Attributes&) = default;
+    Attributes(Attributes&&) = default;
+    auto operator=(const Attributes&) -> Attributes& = default;
+    auto operator=(Attributes&&) -> Attributes& = default;
 
     [[nodiscard]] auto has(uint16_t type) const -> bool;
     [[nodiscard]] auto getString(uint16_t type) const -> std::optional<std::string>;
@@ -36,36 +37,33 @@ class Attributes
   private:
     explicit Attributes(std::size_t toAlloc);
 
-    template <typename T>
-    auto getTypedAttribute(uint16_t type, mnl_attr_data_type mnlType, T (*getter)(const nlattr *)) const
+    template<typename T>
+    auto getTypedAttribute(uint16_t type, mnl_attr_data_type mnlType, T (*getter)(const nlattr*)) const
         -> std::optional<T>
     {
-        if (!has(type))
-        {
+        if (!has(type)) {
             return std::nullopt;
         }
-        if (mnl_attr_validate(m_attributes[type], mnlType) < 0)
-        {
+        if (mnl_attr_validate(m_attributes[type], mnlType) < 0) {
             spdlog::warn("attribute of type {} is invalid", type);
             return std::nullopt;
         }
         return getter(m_attributes[type]);
     }
 
-    template <std::size_t N> [[nodiscard]] auto getPayload(uint16_t type) const -> std::optional<std::array<uint8_t, N>>
+    template<std::size_t N>
+    [[nodiscard]] auto getPayload(uint16_t type) const -> std::optional<std::array<uint8_t, N>>
     {
-        if (!has(type))
-        {
+        if (!has(type)) {
             return std::nullopt;
         }
 
-        if (mnl_attr_validate2(m_attributes[type], MNL_TYPE_UNSPEC, N) < 0)
-        {
+        if (mnl_attr_validate2(m_attributes[type], MNL_TYPE_UNSPEC, N) < 0) {
             spdlog::trace("payload of type {} has len {} != {}", type, mnl_attr_get_payload_len(m_attributes[type]), N);
             return std::nullopt;
         }
 
-        const auto *payload = static_cast<const uint8_t *>(mnl_attr_get_payload(m_attributes[type]));
+        const auto* payload = static_cast<const uint8_t*>(mnl_attr_get_payload(m_attributes[type]));
         std::array<uint8_t, N> arr;
         std::copy_n(payload, N, arr.data());
         return arr;
@@ -73,13 +71,13 @@ class Attributes
 
     struct CallbackArgs
     {
-        Attributes *attrs;
-        uint64_t *counter;
+        Attributes* attrs;
+        uint64_t* counter;
     };
 
-    void parseAttribute(const nlattr *a, uint64_t &counter);
-    static auto dispatchMnlAttributeCallback(const nlattr *attr, void *args) -> int;
+    void parseAttribute(const nlattr* a, uint64_t& counter);
+    static auto dispatchMnlAttributeCallback(const nlattr* attr, void* args) -> int;
 
-    std::vector<const nlattr *> m_attributes;
+    std::vector<const nlattr*> m_attributes;
 };
-} // namespace monkas::monitor
+}  // namespace monkas::monitor

--- a/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
+++ b/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
@@ -2,12 +2,13 @@
 
 #include <bitset>
 #include <chrono>
-#include <ethernet/Address.hpp>
-#include <fmt/ostream.h>
-#include <network/Address.hpp>
 #include <set>
 #include <string>
 #include <type_traits>
+
+#include <ethernet/Address.hpp>
+#include <fmt/ostream.h>
+#include <network/Address.hpp>
 
 namespace monkas::monitor
 {
@@ -52,26 +53,26 @@ class NetworkInterfaceStatusTracker
 
     NetworkInterfaceStatusTracker();
 
-    [[nodiscard]] auto name() const -> const std::string &;
-    void setName(const std::string &name);
+    [[nodiscard]] auto name() const -> const std::string&;
+    void setName(const std::string& name);
 
     [[nodiscard]] auto operationalState() const -> OperationalState;
     void setOperationalState(OperationalState operstate);
 
-    [[nodiscard]] auto macAddress() const -> const ethernet::Address &;
-    void setMacAddress(const ethernet::Address &address);
+    [[nodiscard]] auto macAddress() const -> const ethernet::Address&;
+    void setMacAddress(const ethernet::Address& address);
 
-    [[nodiscard]] auto broadcastAddress() const -> const ethernet::Address &;
-    void setBroadcastAddress(const ethernet::Address &address);
+    [[nodiscard]] auto broadcastAddress() const -> const ethernet::Address&;
+    void setBroadcastAddress(const ethernet::Address& address);
 
-    [[nodiscard]] auto gatewayAddress() const -> const ip::Address &;
-    void setGatewayAddress(const ip::Address &gateway);
+    [[nodiscard]] auto gatewayAddress() const -> const ip::Address&;
+    void setGatewayAddress(const ip::Address& gateway);
     void clearGatewayAddress(GatewayClearReason r);
 
-    [[nodiscard]] auto networkAddresses() const -> const Addresses &;
+    [[nodiscard]] auto networkAddresses() const -> const Addresses&;
 
-    void addNetworkAddress(const network::Address &address);
-    void removeNetworkAddress(const network::Address &address);
+    void addNetworkAddress(const network::Address& address);
+    void removeNetworkAddress(const network::Address& address);
 
     [[nodiscard]] auto age() const -> Duration;
 
@@ -86,11 +87,11 @@ class NetworkInterfaceStatusTracker
     void touch(DirtyFlag flag);
 
     // TODO: only use public api
-    friend auto operator<<(std::ostream &o, const NetworkInterfaceStatusTracker &s) -> std::ostream &;
+    friend auto operator<<(std::ostream& o, const NetworkInterfaceStatusTracker& s) -> std::ostream&;
     std::string m_name;
     ethernet::Address m_macAddress;
     ethernet::Address m_broadcastAddress;
-    OperationalState m_operState{OperationalState::Unknown};
+    OperationalState m_operState {OperationalState::Unknown};
     Addresses m_networkAddresses;
     ip::Address m_gateway;
     std::chrono::time_point<std::chrono::steady_clock> m_lastChanged;
@@ -98,32 +99,37 @@ class NetworkInterfaceStatusTracker
 };
 
 using OperationalState = NetworkInterfaceStatusTracker::OperationalState;
-auto operator<<(std::ostream &o, OperationalState op) -> std::ostream &;
+auto operator<<(std::ostream& o, OperationalState op) -> std::ostream&;
 using GatewayClearReason = NetworkInterfaceStatusTracker::GatewayClearReason;
-auto operator<<(std::ostream &o, GatewayClearReason r) -> std::ostream &;
+auto operator<<(std::ostream& o, GatewayClearReason r) -> std::ostream&;
 using DirtyFlag = NetworkInterfaceStatusTracker::DirtyFlag;
 using DirtyFlags = NetworkInterfaceStatusTracker::DirtyFlags;
-auto operator<<(std::ostream &o, DirtyFlag d) -> std::ostream &;
-auto operator<<(std::ostream &o, const DirtyFlags &d) -> std::ostream &;
+auto operator<<(std::ostream& o, DirtyFlag d) -> std::ostream&;
+auto operator<<(std::ostream& o, const DirtyFlags& d) -> std::ostream&;
 
-} // namespace monkas::monitor
+}  // namespace monkas::monitor
 
-template <> struct fmt::formatter<monkas::monitor::NetworkInterfaceStatusTracker> : fmt::ostream_formatter
+template<>
+struct fmt::formatter<monkas::monitor::NetworkInterfaceStatusTracker> : fmt::ostream_formatter
 {
 };
 
-template <> struct fmt::formatter<monkas::monitor::OperationalState> : fmt::ostream_formatter
+template<>
+struct fmt::formatter<monkas::monitor::OperationalState> : fmt::ostream_formatter
 {
 };
 
-template <> struct fmt::formatter<monkas::monitor::GatewayClearReason> : fmt::ostream_formatter
+template<>
+struct fmt::formatter<monkas::monitor::GatewayClearReason> : fmt::ostream_formatter
 {
 };
 
-template <> struct fmt::formatter<monkas::monitor::DirtyFlag> : fmt::ostream_formatter
+template<>
+struct fmt::formatter<monkas::monitor::DirtyFlag> : fmt::ostream_formatter
 {
 };
 
-template <> struct fmt::formatter<monkas::monitor::DirtyFlags> : fmt::ostream_formatter
+template<>
+struct fmt::formatter<monkas::monitor::DirtyFlags> : fmt::ostream_formatter
 {
 };

--- a/include/monkas/monitor/NetworkMonitor.hpp
+++ b/include/monkas/monitor/NetworkMonitor.hpp
@@ -2,13 +2,14 @@
 
 #include <chrono>
 #include <cstdint>
-#include <ip/Address.hpp>
 #include <map>
 #include <memory>
-#include <monitor/NetworkInterfaceStatusTracker.hpp>
-#include <network/Interface.hpp>
 #include <optional>
 #include <vector>
+
+#include <ip/Address.hpp>
+#include <monitor/NetworkInterfaceStatusTracker.hpp>
+#include <network/Interface.hpp>
 #include <watchable/Watchable.hpp>
 
 // TODO: sometimes an enthernet interface comes up with Unknown operstate, ip link shows the same info, what do we want
@@ -79,47 +80,47 @@ using EnumerationDoneWatcherToken = EnumerationDoneNotifier::Token;
 class NetworkMonitor
 {
   public:
-    explicit NetworkMonitor(const RuntimeOptions &options);
+    explicit NetworkMonitor(const RuntimeOptions& options);
     void enumerateInterfaces();
     auto run() -> int;
     void stop();
 
     [[nodiscard]] auto addInterfacesWatcher(
-        const InterfacesWatcher &watcher, InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot)
+        const InterfacesWatcher& watcher, InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot)
         -> InterfacesWatcherToken;
-    void removeInterfacesWatcher(const InterfacesWatcherToken &token);
+    void removeInterfacesWatcher(const InterfacesWatcherToken& token);
 
     [[nodiscard]] auto addOperationalStateWatcher(
-        const OperationalStateWatcher &watcher,
+        const OperationalStateWatcher& watcher,
         InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot) -> OperationalStateWatcherToken;
-    void removeOperationalStateWatcher(const OperationalStateWatcherToken &token);
+    void removeOperationalStateWatcher(const OperationalStateWatcherToken& token);
 
     [[nodiscard]] auto addNetworkAddressWatcher(
-        const NetworkAddressWatcher &watcher,
+        const NetworkAddressWatcher& watcher,
         InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot) -> NetworkAddressWatcherToken;
-    void removeNetworkAddressWatcher(const NetworkAddressWatcherToken &token);
+    void removeNetworkAddressWatcher(const NetworkAddressWatcherToken& token);
 
     [[nodiscard]] auto addGatewayAddressWatcher(
-        const GatewayAddressWatcher &watcher,
+        const GatewayAddressWatcher& watcher,
         InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot) -> GatewayAddressWatcherToken;
-    void removeGatewayAddressWatcher(const GatewayAddressWatcherToken &token);
+    void removeGatewayAddressWatcher(const GatewayAddressWatcherToken& token);
 
     [[nodiscard]] auto addMacAddressWatcher(
-        const MacAddressWatcher &watcher, InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot)
+        const MacAddressWatcher& watcher, InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot)
         -> MacAddressWatcherToken;
-    void removeMacAddressWatcher(const MacAddressWatcherToken &token);
+    void removeMacAddressWatcher(const MacAddressWatcherToken& token);
 
     [[nodiscard]] auto addBroadcastAddressWatcher(
-        const BroadcastAddressWatcher &watcher,
+        const BroadcastAddressWatcher& watcher,
         InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot) -> BroadcastAddressWatcherToken;
 
-    void removeBroadcastAddressWatcher(const BroadcastAddressWatcherToken &token);
+    void removeBroadcastAddressWatcher(const BroadcastAddressWatcherToken& token);
 
     // enumeration done watcher is called when enumeration is done, or immediately if enumeration is already done
     // the optional return value is used to indicate that enumeration is already done
-    [[nodiscard]] auto addEnumerationDoneWatcher(const EnumerationDoneWatcher &watcher)
+    [[nodiscard]] auto addEnumerationDoneWatcher(const EnumerationDoneWatcher& watcher)
         -> std::optional<EnumerationDoneWatcherToken>;
-    void removeEnumerationDoneWatcher(const EnumerationDoneWatcherToken &token);
+    void removeEnumerationDoneWatcher(const EnumerationDoneWatcherToken& token);
 
   private:
     void receiveAndProcess();
@@ -127,46 +128,37 @@ class NetworkMonitor
     /* @note: only one such request can be in progress until the reply is received */
     void sendDumpRequest(uint16_t msgType);
 
-    auto ensureNameCurrent(uint32_t ifIndex, const std::optional<std::string> &name) -> NetworkInterfaceStatusTracker &;
+    auto ensureNameCurrent(uint32_t ifIndex, const std::optional<std::string>& name) -> NetworkInterfaceStatusTracker&;
 
-    void parseLinkMessage(const nlmsghdr *nlhdr, const ifinfomsg *ifi);
-    void parseAddressMessage(const nlmsghdr *nlhdr, const ifaddrmsg *ifa);
-    void parseRouteMessage(const nlmsghdr *nlhdr, const rtmsg *rtm);
+    void parseLinkMessage(const nlmsghdr* nlhdr, const ifinfomsg* ifi);
+    void parseAddressMessage(const nlmsghdr* nlhdr, const ifaddrmsg* ifa);
+    void parseRouteMessage(const nlmsghdr* nlhdr, const rtmsg* rtm);
 
     void printStatsForNerdsIfEnabled();
 
-    auto mnlMessageCallback(const nlmsghdr *n) -> int;
-    static auto dispatchMnMessageCallbackToSelf(const struct nlmsghdr *n, void *self) -> int;
+    auto mnlMessageCallback(const nlmsghdr* n) -> int;
+    static auto dispatchMnMessageCallbackToSelf(const struct nlmsghdr* n, void* self) -> int;
 
-    [[nodiscard]] auto isEnumerating() const -> bool
-    {
-        return m_cacheState != CacheState::WaitingForChanges;
-    }
+    [[nodiscard]] auto isEnumerating() const -> bool { return m_cacheState != CacheState::WaitingForChanges; }
 
-    [[nodiscard]] auto isEnumeratingLinks() const -> bool
-    {
-        return m_cacheState == CacheState::EnumeratingLinks;
-    }
+    [[nodiscard]] auto isEnumeratingLinks() const -> bool { return m_cacheState == CacheState::EnumeratingLinks; }
 
     [[nodiscard]] auto isEnumeratingAddresses() const -> bool
     {
         return m_cacheState == CacheState::EnumeratingAddresses;
     }
 
-    [[nodiscard]] auto isEnumeratingRoutes() const -> bool
-    {
-        return m_cacheState == CacheState::EnumeratingRoutes;
-    }
+    [[nodiscard]] auto isEnumeratingRoutes() const -> bool { return m_cacheState == CacheState::EnumeratingRoutes; }
 
     void notifyChanges();
     void notifyInterfacesSnapshot();
     [[nodiscard]] auto getInterfacesSnapshot() const -> Interfaces;
 
-    std::unique_ptr<mnl_socket, int (*)(mnl_socket *)> m_mnlSocket;
+    std::unique_ptr<mnl_socket, int (*)(mnl_socket*)> m_mnlSocket;
     std::vector<uint8_t> m_buffer;
-    bool m_running{false};
-    uint32_t m_portid{};
-    uint32_t m_sequenceNumber{};
+    bool m_running {false};
+    uint32_t m_portid {};
+    uint32_t m_sequenceNumber {};
 
     std::map<uint32_t, NetworkInterfaceStatusTracker> m_trackers;
 
@@ -176,21 +168,21 @@ class NetworkMonitor
         EnumeratingAddresses,
         EnumeratingRoutes,
         WaitingForChanges
-    } m_cacheState{CacheState::EnumeratingLinks};
+    } m_cacheState {CacheState::EnumeratingLinks};
 
     struct Statistics
     {
         std::chrono::time_point<std::chrono::steady_clock> startTime;
-        uint64_t bytesSent{};
-        uint64_t bytesReceived{};
-        uint64_t packetsSent{};
-        uint64_t packetsReceived{};
-        uint64_t msgsReceived{};
-        uint64_t msgsDiscarded{};
-        uint64_t seenAttributes{};
-        uint64_t addressMessagesSeen{};
-        uint64_t linkMessagesSeen{};
-        uint64_t routeMessagesSeen{};
+        uint64_t bytesSent {};
+        uint64_t bytesReceived {};
+        uint64_t packetsSent {};
+        uint64_t packetsReceived {};
+        uint64_t msgsReceived {};
+        uint64_t msgsDiscarded {};
+        uint64_t seenAttributes {};
+        uint64_t addressMessagesSeen {};
+        uint64_t linkMessagesSeen {};
+        uint64_t routeMessagesSeen {};
     } m_stats;
 
     RuntimeOptions m_runtimeOptions;
@@ -202,4 +194,4 @@ class NetworkMonitor
     BroadcastAddressNotifier m_broadcastAddressNotifier;
     EnumerationDoneNotifier m_enumerationDoneNotifier;
 };
-} // namespace monkas::monitor
+}  // namespace monkas::monitor

--- a/include/monkas/network/Address.hpp
+++ b/include/monkas/network/Address.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <compare>
+
 #include <fmt/ostream.h>
 #include <ip/Address.hpp>
 
@@ -16,7 +17,7 @@ enum class Scope : uint8_t
     Host,
     Nowhere,
 };
-auto operator<<(std::ostream &o, Scope a) -> std::ostream &;
+auto operator<<(std::ostream& o, Scope a) -> std::ostream&;
 
 auto fromRtnlScope(uint8_t rtnlScope) -> Scope;
 
@@ -24,7 +25,11 @@ class Address
 {
   public:
     Address() = default;
-    Address(const ip::Address &address, const ip::Address &broadcast, uint8_t prefixLen, Scope scope, uint32_t flags,
+    Address(const ip::Address& address,
+            const ip::Address& broadcast,
+            uint8_t prefixLen,
+            Scope scope,
+            uint32_t flags,
             uint8_t proto);
     /**
      * @returns true if AddressFamily is not Unspecified
@@ -38,29 +43,30 @@ class Address
     [[nodiscard]] auto isUnspecified() const -> bool;
     [[nodiscard]] auto isMappedV4() const -> bool;
 
-    [[nodiscard]] auto ip() const -> const ip::Address &;
-    [[nodiscard]] auto broadcast() const -> const ip::Address &;
+    [[nodiscard]] auto ip() const -> const ip::Address&;
+    [[nodiscard]] auto broadcast() const -> const ip::Address&;
     [[nodiscard]] auto prefixLength() const -> uint8_t;
     [[nodiscard]] auto scope() const -> Scope;
     [[nodiscard]] auto flags() const -> uint32_t;
     [[nodiscard]] auto proto() const -> uint8_t;
 
-    [[nodiscard]] auto operator<=>(const Address &other) const -> std::strong_ordering;
-    [[nodiscard]] auto operator==(const Address &other) const -> bool = default;
+    [[nodiscard]] auto operator<=>(const Address& other) const -> std::strong_ordering;
+    [[nodiscard]] auto operator==(const Address& other) const -> bool = default;
 
   private:
     ip::Address m_ip;
     ip::Address m_brd;
-    uint8_t m_prefixlen{};
-    Scope m_scope{Scope::Nowhere};
-    uint32_t m_flags{};
-    uint8_t m_prot{0};
+    uint8_t m_prefixlen {};
+    Scope m_scope {Scope::Nowhere};
+    uint32_t m_flags {};
+    uint8_t m_prot {0};
 };
 
-auto operator<<(std::ostream &o, const Address &a) -> std::ostream &;
+auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;
 
-} // namespace monkas::network
+}  // namespace monkas::network
 
-template <> struct fmt::formatter<monkas::network::Address> : fmt::ostream_formatter
+template<>
+struct fmt::formatter<monkas::network::Address> : fmt::ostream_formatter
 {
 };

--- a/include/monkas/network/Interface.hpp
+++ b/include/monkas/network/Interface.hpp
@@ -1,10 +1,11 @@
 #pragma once
 
 #include <cstdint>
-#include <fmt/ostream.h>
 #include <iosfwd>
 #include <string>
 #include <tuple>
+
+#include <fmt/ostream.h>
 
 namespace monkas::network
 {
@@ -14,40 +15,32 @@ class Interface
     Interface() = default;
     Interface(std::uint32_t index, std::string name);
 
-    [[nodiscard]] auto index() const -> uint32_t
-    {
-        return m_index;
-    }
+    [[nodiscard]] auto index() const -> uint32_t { return m_index; }
 
-    [[nodiscard]] auto name() const -> const std::string &
-    {
-        return m_name;
-    }
+    [[nodiscard]] auto name() const -> const std::string& { return m_name; }
 
-    constexpr auto operator<(const Interface &other) const noexcept -> bool
+    constexpr auto operator<(const Interface& other) const noexcept -> bool
     {
         return std::tie(m_index, m_name) < std::tie(other.m_index, other.m_name);
     }
 
-    constexpr auto operator==(const Interface &other) const -> bool
+    constexpr auto operator==(const Interface& other) const -> bool
     {
         return m_index == other.m_index && m_name == other.m_name;
     }
 
-    constexpr auto operator!=(const Interface &other) const -> bool
-    {
-        return !(*this == other);
-    }
+    constexpr auto operator!=(const Interface& other) const -> bool { return !(*this == other); }
 
   private:
-    uint32_t m_index{};
+    uint32_t m_index {};
     std::string m_name;
 };
 
-auto operator<<(std::ostream &os, const Interface &iface) -> std::ostream &;
+auto operator<<(std::ostream& os, const Interface& iface) -> std::ostream&;
 
-} // namespace monkas::network
+}  // namespace monkas::network
 
-template <> struct fmt::formatter<monkas::network::Interface> : fmt::ostream_formatter
+template<>
+struct fmt::formatter<monkas::network::Interface> : fmt::ostream_formatter
 {
 };

--- a/src/ethernet/Address.cpp
+++ b/src/ethernet/Address.cpp
@@ -1,21 +1,20 @@
-#include <ethernet/Address.hpp>
-
 #include <algorithm>
 #include <cstdio>
 #include <ostream>
+
+#include <ethernet/Address.hpp>
 
 namespace monkas::ethernet
 {
 
 Address::Address()
-    : std::array<uint8_t, ADDR_LEN>{}
+    : std::array<uint8_t, ADDR_LEN> {}
 {
 }
 
-auto Address::fromBytes(const uint8_t *bytes, size_type len) -> Address
+auto Address::fromBytes(const uint8_t* bytes, size_type len) -> Address
 {
-    if (bytes == nullptr || len != ADDR_LEN)
-    {
+    if (bytes == nullptr || len != ADDR_LEN) {
         return {};
     }
     Address r;
@@ -24,29 +23,26 @@ auto Address::fromBytes(const uint8_t *bytes, size_type len) -> Address
     return r;
 }
 
-auto Address::fromBytes(const std::array<uint8_t, ADDR_LEN> &bytes) -> Address
+auto Address::fromBytes(const std::array<uint8_t, ADDR_LEN>& bytes) -> Address
 {
     return fromBytes(bytes.data(), bytes.size());
 }
 
 auto Address::toString() const -> std::string
 {
-    if (!m_isValid)
-    {
+    if (!m_isValid) {
         return {"Invalid"};
     }
-    constexpr auto LEN = 17; // 6*2 hex digits + 5 colons
-    std::array<char, LEN> buf{};
+    constexpr auto LEN = 17;  // 6*2 hex digits + 5 colons
+    std::array<char, LEN> buf {};
     int idx = 0;
     int i = 0;
     constexpr auto LOWER_NIBBLE_SHIFT = 0x4U;
     constexpr auto UPPER_NIBBLE_MASK = 0xFU;
-    for (const auto octet : *this)
-    {
+    for (const auto octet : *this) {
         buf[idx++] = "0123456789abcdef"[octet >> LOWER_NIBBLE_SHIFT];
         buf[idx++] = "0123456789abcdef"[octet & UPPER_NIBBLE_MASK];
-        if (i < size() - 1)
-        {
+        if (i < size() - 1) {
             buf[idx++] = ':';
         }
         i++;
@@ -59,35 +55,31 @@ Address::operator bool() const
     return m_isValid;
 }
 
-auto Address::operator<=>(const Address &other) const -> std::strong_ordering
+auto Address::operator<=>(const Address& other) const -> std::strong_ordering
 {
-    if (!m_isValid && !other.m_isValid)
-    {
+    if (!m_isValid && !other.m_isValid) {
         return std::strong_ordering::equal;
     }
-    if (!m_isValid)
-    {
+    if (!m_isValid) {
         return std::strong_ordering::less;
     }
-    if (!other.m_isValid)
-    {
+    if (!other.m_isValid) {
         return std::strong_ordering::greater;
     }
     return std::lexicographical_compare_three_way(begin(), end(), other.begin(), other.end());
 }
 
-auto Address::operator==(const Address &other) const -> bool
+auto Address::operator==(const Address& other) const -> bool
 {
-    if (!m_isValid || !other.m_isValid)
-    {
+    if (!m_isValid || !other.m_isValid) {
         return false;
     }
     return std::equal(begin(), end(), other.begin());
 }
 
-auto operator<<(std::ostream &o, const Address &a) -> std::ostream &
+auto operator<<(std::ostream& o, const Address& a) -> std::ostream&
 {
     return o << a.toString();
 }
 
-} // namespace monkas::ethernet
+}  // namespace monkas::ethernet

--- a/src/ethernet/Address.test.cpp
+++ b/src/ethernet/Address.test.cpp
@@ -8,13 +8,12 @@ using namespace monkas::ethernet;
 
 TEST_SUITE("[ethernet::Address]")
 {
-
-    std::array<uint8_t, ADDR_LEN> bytesNull{0, 0, 0, 0, 0, 0};
-    std::array<uint8_t, ADDR_LEN> bytesSome{1, 2, 3, 4, 5, 0x1A};
+    std::array<uint8_t, ADDR_LEN> bytesNull {0, 0, 0, 0, 0, 0};
+    std::array<uint8_t, ADDR_LEN> bytesSome {1, 2, 3, 4, 5, 0x1A};
 
     const auto someAddress = Address::fromBytes(bytesSome);
     const auto nullAddress = Address::fromBytes(bytesNull);
-    const auto defaultAddress = Address{};
+    const auto defaultAddress = Address {};
 
     TEST_CASE("toString")
     {
@@ -52,4 +51,4 @@ TEST_SUITE("[ethernet::Address]")
 }
 
 // NOLINTEND(*)
-} // namespace
+}  // namespace

--- a/src/ip/Address.test.cpp
+++ b/src/ip/Address.test.cpp
@@ -9,18 +9,18 @@ using namespace monkas::ip;
 
 TEST_SUITE("[ip::Address]")
 {
-    std::array<uint8_t, 4> bytesAny4{};
-    std::array<uint8_t, 4> bytesV4CountUp{1, 2, 3, 4};
-    std::array<uint8_t, 4> bytesV4CountDown{4, 3, 2, 1};
-    std::array<uint8_t, 4> bytesLocalhost4{127, 0, 0, 1};
-    std::array<uint8_t, 4> bytesLocalhost4OtherSubnet{127, 0, 1, 1};
+    std::array<uint8_t, 4> bytesAny4 {};
+    std::array<uint8_t, 4> bytesV4CountUp {1, 2, 3, 4};
+    std::array<uint8_t, 4> bytesV4CountDown {4, 3, 2, 1};
+    std::array<uint8_t, 4> bytesLocalhost4 {127, 0, 0, 1};
+    std::array<uint8_t, 4> bytesLocalhost4OtherSubnet {127, 0, 1, 1};
 
-    std::array<uint8_t, 16> bytesAny6{};
-    std::array<uint8_t, 16> bytesLocalHost6{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
-    std::array<uint8_t, 16> bytesV6CountUp{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
-    std::array<uint8_t, 16> bytesV6CountDown{16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
+    std::array<uint8_t, 16> bytesAny6 {};
+    std::array<uint8_t, 16> bytesLocalHost6 {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1};
+    std::array<uint8_t, 16> bytesV6CountUp {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
+    std::array<uint8_t, 16> bytesV6CountDown {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
 
-    std::array<uint8_t, 16> bytesLocalhostV4mapped{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 127, 0, 0, 1};
+    std::array<uint8_t, 16> bytesLocalhostV4mapped {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 127, 0, 0, 1};
 
     const auto any4 = Address::fromBytes(bytesAny4);
     const auto any6 = Address::fromBytes(bytesAny6);
@@ -32,7 +32,7 @@ TEST_SUITE("[ip::Address]")
     const auto countDownV4 = Address::fromBytes(bytesV4CountDown);
     const auto countUpV6 = Address::fromBytes(bytesV6CountUp);
     const auto countDownV6 = Address::fromBytes(bytesV6CountDown);
-    const auto unspec = Address{};
+    const auto unspec = Address {};
 
     TEST_CASE("toString")
     {
@@ -251,4 +251,4 @@ TEST_SUITE("[ip::Address]")
 }
 
 // NOLINTEND(*)
-} // namespace
+}  // namespace

--- a/src/monitor/Attributes.cpp
+++ b/src/monitor/Attributes.cpp
@@ -6,10 +6,10 @@
 namespace monkas::monitor
 {
 
-auto Attributes::parse(const nlmsghdr *n, size_t offset, uint16_t maxType, u_int64_t &counter) -> Attributes
+auto Attributes::parse(const nlmsghdr* n, size_t offset, uint16_t maxType, u_int64_t& counter) -> Attributes
 {
-    Attributes attributes{maxType + 1U};
-    CallbackArgs arg{.attrs = &attributes, .counter = &counter};
+    Attributes attributes {maxType + 1U};
+    CallbackArgs arg {.attrs = &attributes, .counter = &counter};
     mnl_attr_parse(n, offset, &Attributes::dispatchMnlAttributeCallback, &arg);
     return attributes;
 }
@@ -19,23 +19,20 @@ Attributes::Attributes(std::size_t toAlloc)
 {
 }
 
-void Attributes::parseAttribute(const nlattr *a, uint64_t &counter)
+void Attributes::parseAttribute(const nlattr* a, uint64_t& counter)
 {
     const auto type = mnl_attr_get_type(a);
-    if (mnl_attr_type_valid(a, m_attributes.size() - 1) > 0)
-    {
+    if (mnl_attr_type_valid(a, m_attributes.size() - 1) > 0) {
         counter++;
         m_attributes[type] = a;
-    }
-    else
-    {
+    } else {
         spdlog::warn("ignoring unexpected nlattr type {}", type);
     }
 }
 
-auto Attributes::dispatchMnlAttributeCallback(const nlattr *attr, void *args) -> int
+auto Attributes::dispatchMnlAttributeCallback(const nlattr* attr, void* args) -> int
 {
-    auto *cb = static_cast<CallbackArgs *>(args);
+    auto* cb = static_cast<CallbackArgs*>(args);
     cb->attrs->parseAttribute(attr, *cb->counter);
     return MNL_CB_OK;
 }
@@ -47,9 +44,8 @@ auto Attributes::has(uint16_t type) const -> bool
 
 auto Attributes::getString(uint16_t type) const -> std::optional<std::string>
 {
-    return getTypedAttribute<const char *>(type, MNL_TYPE_STRING, mnl_attr_get_str).transform([](const char *str) {
-        return std::string(str);
-    });
+    return getTypedAttribute<const char*>(type, MNL_TYPE_STRING, mnl_attr_get_str)
+        .transform([](const char* str) { return std::string(str); });
 }
 
 auto Attributes::getU8(uint16_t type) const -> std::optional<uint8_t>
@@ -74,17 +70,17 @@ auto Attributes::getU64(uint16_t type) const -> std::optional<uint64_t>
 
 auto Attributes::getEthernetAddress(uint16_t type) const -> std::optional<ethernet::Address>
 {
-    return getPayload<ethernet::ADDR_LEN>(type).transform(
-        [](const auto &arr) { return ethernet::Address::fromBytes(arr); });
+    return getPayload<ethernet::ADDR_LEN>(type).transform([](const auto& arr)
+                                                          { return ethernet::Address::fromBytes(arr); });
 }
 
 auto Attributes::getIpV6Address(uint16_t type) const -> std::optional<ip::Address>
 {
-    return getPayload<ip::IPV6_ADDR_LEN>(type).transform([](const auto &arr) { return ip::Address::fromBytes(arr); });
+    return getPayload<ip::IPV6_ADDR_LEN>(type).transform([](const auto& arr) { return ip::Address::fromBytes(arr); });
 }
 
 auto Attributes::getIpV4Address(uint16_t type) const -> std::optional<ip::Address>
 {
-    return getPayload<ip::IPV4_ADDR_LEN>(type).transform([](const auto &arr) { return ip::Address::fromBytes(arr); });
+    return getPayload<ip::IPV4_ADDR_LEN>(type).transform([](const auto& arr) { return ip::Address::fromBytes(arr); });
 }
-} // namespace monkas::monitor
+}  // namespace monkas::monitor

--- a/src/monitor/NetworkMonitor.cpp
+++ b/src/monitor/NetworkMonitor.cpp
@@ -1,23 +1,25 @@
-#include "ethernet/Address.hpp"
 #include <cstddef>
-#include <ip/Address.hpp>
-#include <linux/if_link.h>
-#include <monitor/Attributes.hpp>
-#include <monitor/NetworkMonitor.hpp>
 
 #include <fmt/std.h>
+#include <ip/Address.hpp>
 #include <libmnl/libmnl.h>
+#include <linux/if_link.h>
 #include <linux/rtnetlink.h>
 #include <memory.h>
+#include <monitor/Attributes.hpp>
+#include <monitor/NetworkMonitor.hpp>
 #include <net/if_arp.h>
 #include <spdlog/common.h>
 #include <spdlog/spdlog.h>
+
+#include "ethernet/Address.hpp"
 
 namespace monkas::monitor
 {
 namespace
 {
-template <typename T> [[noreturn]] void pfatal(const T &msg)
+template<typename T>
+[[noreturn]] void pfatal(const T& msg)
 {
     spdlog::flush_on(spdlog::level::critical);
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
@@ -25,7 +27,8 @@ template <typename T> [[noreturn]] void pfatal(const T &msg)
     std::abort();
 }
 
-template <typename T> void pwarn(const T &msg)
+template<typename T>
+void pwarn(const T& msg)
 {
     // NOLINTNEXTLINE(concurrency-mt-unsafe)
     spdlog::warn("{} failed: {}[{}]", msg, strerror(errno), errno);
@@ -38,54 +41,48 @@ auto toRtnlGroupFlag(rtnetlink_groups group) -> unsigned
 
 inline constexpr size_t SOCKET_BUFFER_SIZE = static_cast<const size_t>(32U * 1024U);
 
-auto ensureMnlSocket(bool nonBlocking) -> mnl_socket *
+auto ensureMnlSocket(bool nonBlocking) -> mnl_socket*
 {
-    auto *s = mnl_socket_open2(NETLINK_ROUTE, nonBlocking ? SOCK_NONBLOCK : 0);
-    if (s == nullptr)
-    {
+    auto* s = mnl_socket_open2(NETLINK_ROUTE, nonBlocking ? SOCK_NONBLOCK : 0);
+    if (s == nullptr) {
         pfatal("mnl_socket_open2");
     }
     return s;
 }
-} // namespace
+}  // namespace
 
-NetworkMonitor::NetworkMonitor(const RuntimeOptions &options)
-    : m_mnlSocket{ensureMnlSocket(options.test(NonBlocking)), mnl_socket_close}
-    , m_portid{mnl_socket_get_portid(m_mnlSocket.get())}
+NetworkMonitor::NetworkMonitor(const RuntimeOptions& options)
+    : m_mnlSocket {ensureMnlSocket(options.test(NonBlocking)), mnl_socket_close}
+    , m_portid {mnl_socket_get_portid(m_mnlSocket.get())}
     , m_buffer(SOCKET_BUFFER_SIZE)
     , m_runtimeOptions(options)
 {
     m_stats.startTime = std::chrono::steady_clock::now();
     unsigned groups = toRtnlGroupFlag(RTNLGRP_LINK);
     groups |= toRtnlGroupFlag(RTNLGRP_NOTIFY);
-    if (!m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV6))
-    {
+    if (!m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV6)) {
         groups |= toRtnlGroupFlag(RTNLGRP_IPV4_IFADDR);
         groups |= toRtnlGroupFlag(RTNLGRP_IPV4_ROUTE);
     }
-    if (!m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV4))
-    {
+    if (!m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV4)) {
         groups |= toRtnlGroupFlag(RTNLGRP_IPV6_IFADDR);
         groups |= toRtnlGroupFlag(RTNLGRP_IPV6_ROUTE);
     }
     spdlog::debug("Joining RTnetlink multicast groups {}", groups);
-    if (mnl_socket_bind(m_mnlSocket.get(), groups, MNL_SOCKET_AUTOPID) < 0)
-    {
+    if (mnl_socket_bind(m_mnlSocket.get(), groups, MNL_SOCKET_AUTOPID) < 0) {
         pfatal("mnl_socket_bind");
     }
 }
 
 void NetworkMonitor::enumerateInterfaces()
 {
-    if (m_cacheState == CacheState::WaitingForChanges)
-    {
+    if (m_cacheState == CacheState::WaitingForChanges) {
         spdlog::trace("Already enumerated interfaces, skipping");
         return;
     }
     spdlog::debug("Requesting RTM_GETLINK");
     sendDumpRequest(RTM_GETLINK);
-    while (m_cacheState != CacheState::WaitingForChanges)
-    {
+    while (m_cacheState != CacheState::WaitingForChanges) {
         receiveAndProcess();
     }
 }
@@ -93,17 +90,16 @@ void NetworkMonitor::enumerateInterfaces()
 auto NetworkMonitor::run() -> int
 {
     // someone may call enumerateInterfaces() and stop() during enumerateInterfaces
-    if (!m_mnlSocket)
-    {
+    if (!m_mnlSocket) {
         return 0;
     }
     m_running = true;
     spdlog::trace("Starting NetworkMonitor");
     enumerateInterfaces();
     spdlog::trace("Starting to receive and process messages from mnl socket {} m_running={}",
-                  static_cast<void *>(m_mnlSocket.get()), m_running);
-    while (m_running)
-    {
+                  static_cast<void*>(m_mnlSocket.get()),
+                  m_running);
+    while (m_running) {
         receiveAndProcess();
     }
     return 0;
@@ -116,128 +112,116 @@ void NetworkMonitor::stop()
     m_running = false;
 }
 
-auto NetworkMonitor::addInterfacesWatcher(const InterfacesWatcher &watcher, InitialSnapshotMode initialSnapshot)
+auto NetworkMonitor::addInterfacesWatcher(const InterfacesWatcher& watcher, InitialSnapshotMode initialSnapshot)
     -> InterfacesWatcherToken
 {
-    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot)
-    {
+    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot) {
         watcher(getInterfacesSnapshot());
     }
     return m_interfacesNotifier.addWatcher(watcher);
 }
 
-void NetworkMonitor::removeInterfacesWatcher(const InterfacesWatcherToken &token)
+void NetworkMonitor::removeInterfacesWatcher(const InterfacesWatcherToken& token)
 {
     m_interfacesNotifier.removeWatcher(token);
 }
 
-auto NetworkMonitor::addOperationalStateWatcher(const OperationalStateWatcher &watcher,
+auto NetworkMonitor::addOperationalStateWatcher(const OperationalStateWatcher& watcher,
                                                 InitialSnapshotMode initialSnapshot) -> OperationalStateWatcherToken
 {
-    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot)
-    {
-        for (auto &[index, tracker] : m_trackers)
-        {
-            watcher(network::Interface{index, tracker.name()}, tracker.operationalState());
+    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot) {
+        for (auto& [index, tracker] : m_trackers) {
+            watcher(network::Interface {index, tracker.name()}, tracker.operationalState());
             tracker.clearFlag(DirtyFlag::OperationalStateChanged);
         }
     }
     return m_operationalStateNotifier.addWatcher(watcher);
 }
 
-void NetworkMonitor::removeOperationalStateWatcher(const OperationalStateWatcherToken &token)
+void NetworkMonitor::removeOperationalStateWatcher(const OperationalStateWatcherToken& token)
 {
     m_operationalStateNotifier.removeWatcher(token);
 }
 
-auto NetworkMonitor::addNetworkAddressWatcher(const NetworkAddressWatcher &watcher, InitialSnapshotMode initialSnapshot)
+auto NetworkMonitor::addNetworkAddressWatcher(const NetworkAddressWatcher& watcher, InitialSnapshotMode initialSnapshot)
     -> NetworkAddressWatcherToken
 {
-    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot)
-    {
-        for (auto &[index, tracker] : m_trackers)
-        {
-            watcher(network::Interface{index, tracker.name()}, tracker.networkAddresses());
+    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot) {
+        for (auto& [index, tracker] : m_trackers) {
+            watcher(network::Interface {index, tracker.name()}, tracker.networkAddresses());
             tracker.clearFlag(DirtyFlag::NetworkAddressesChanged);
         }
     }
     return m_networkAddressNotifier.addWatcher(watcher);
 }
 
-void NetworkMonitor::removeNetworkAddressWatcher(const NetworkAddressWatcherToken &token)
+void NetworkMonitor::removeNetworkAddressWatcher(const NetworkAddressWatcherToken& token)
 {
     m_networkAddressNotifier.removeWatcher(token);
 }
 
-auto NetworkMonitor::addGatewayAddressWatcher(const GatewayAddressWatcher &watcher, InitialSnapshotMode initialSnapshot)
+auto NetworkMonitor::addGatewayAddressWatcher(const GatewayAddressWatcher& watcher, InitialSnapshotMode initialSnapshot)
     -> GatewayAddressWatcherToken
 {
-    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot)
-    {
-        for (auto &[index, tracker] : m_trackers)
-        {
-            watcher(network::Interface{index, tracker.name()}, tracker.gatewayAddress());
+    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot) {
+        for (auto& [index, tracker] : m_trackers) {
+            watcher(network::Interface {index, tracker.name()}, tracker.gatewayAddress());
             tracker.clearFlag(DirtyFlag::GatewayAddressChanged);
         }
     }
     return m_gatewayAddressNotifier.addWatcher(watcher);
 }
 
-void NetworkMonitor::removeGatewayAddressWatcher(const GatewayAddressWatcherToken &token)
+void NetworkMonitor::removeGatewayAddressWatcher(const GatewayAddressWatcherToken& token)
 {
     m_gatewayAddressNotifier.removeWatcher(token);
 }
 
-auto NetworkMonitor::addMacAddressWatcher(const MacAddressWatcher &watcher, InitialSnapshotMode initialSnapshot)
+auto NetworkMonitor::addMacAddressWatcher(const MacAddressWatcher& watcher, InitialSnapshotMode initialSnapshot)
     -> MacAddressWatcherToken
 {
-    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot)
-    {
-        for (auto &[index, tracker] : m_trackers)
-        {
-            watcher(network::Interface{index, tracker.name()}, tracker.macAddress());
+    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot) {
+        for (auto& [index, tracker] : m_trackers) {
+            watcher(network::Interface {index, tracker.name()}, tracker.macAddress());
             tracker.clearFlag(DirtyFlag::MacAddressChanged);
         }
     }
     return m_macAddressNotifier.addWatcher(watcher);
 }
 
-void NetworkMonitor::removeMacAddressWatcher(const MacAddressWatcherToken &token)
+void NetworkMonitor::removeMacAddressWatcher(const MacAddressWatcherToken& token)
 {
     m_macAddressNotifier.removeWatcher(token);
 }
 
-auto NetworkMonitor::addBroadcastAddressWatcher(const BroadcastAddressWatcher &watcher,
+auto NetworkMonitor::addBroadcastAddressWatcher(const BroadcastAddressWatcher& watcher,
                                                 InitialSnapshotMode initialSnapshot) -> BroadcastAddressWatcherToken
 {
-    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot)
-    {
-        for (auto &[index, tracker] : m_trackers)
-        {
-            watcher(network::Interface{index, tracker.name()}, tracker.broadcastAddress());
+    if (initialSnapshot == InitialSnapshotMode::InitialSnapshot) {
+        for (auto& [index, tracker] : m_trackers) {
+            watcher(network::Interface {index, tracker.name()}, tracker.broadcastAddress());
             tracker.clearFlag(DirtyFlag::BroadcastAddressChanged);
         }
     }
     return m_broadcastAddressNotifier.addWatcher(watcher);
 }
 
-void NetworkMonitor::removeBroadcastAddressWatcher(const BroadcastAddressWatcherToken &token)
+void NetworkMonitor::removeBroadcastAddressWatcher(const BroadcastAddressWatcherToken& token)
 {
     m_broadcastAddressNotifier.removeWatcher(token);
 }
 
-auto NetworkMonitor::addEnumerationDoneWatcher(const EnumerationDoneWatcher &watcher)
+auto NetworkMonitor::addEnumerationDoneWatcher(const EnumerationDoneWatcher& watcher)
     -> std::optional<EnumerationDoneWatcherToken>
 {
-    if (m_cacheState == CacheState::WaitingForChanges)
-    {
+    if (m_cacheState == CacheState::WaitingForChanges) {
         watcher();
-        return std::nullopt; // already done with enumeration, no need to notify later
+        return std::nullopt;  // already done with enumeration, no need to notify later
     }
     return m_enumerationDoneNotifier.addWatcher(watcher);
 }
 
-void NetworkMonitor::removeEnumerationDoneWatcher(const EnumerationDoneWatcherToken &token)
+void NetworkMonitor::removeEnumerationDoneWatcher(const EnumerationDoneWatcherToken& token)
 {
     m_enumerationDoneNotifier.removeWatcher(token);
 }
@@ -247,75 +231,58 @@ void NetworkMonitor::removeEnumerationDoneWatcher(const EnumerationDoneWatcherTo
 void NetworkMonitor::receiveAndProcess()
 {
     // someone may call stop() while we are notifying watchers
-    if (!m_mnlSocket)
-    {
+    if (!m_mnlSocket) {
         return;
     }
     spdlog::trace("Receiving messages from mnl socket");
     auto receiveResult = mnl_socket_recvfrom(m_mnlSocket.get(), m_buffer.data(), m_buffer.size());
     spdlog::trace("Received {} bytes", receiveResult);
-    while (receiveResult > 0)
-    {
+    while (receiveResult > 0) {
         m_stats.packetsReceived++;
         m_stats.bytesReceived += receiveResult;
-        if (m_runtimeOptions.test(RuntimeFlag::DumpPackets))
-        {
+        if (m_runtimeOptions.test(RuntimeFlag::DumpPackets)) {
             std::ignore = fflush(stderr);
             std::ignore = fflush(stdout);
             mnl_nlmsg_fprintf(stdout, m_buffer.data(), receiveResult, 0);
         }
         const auto seqNo = isEnumerating() ? m_sequenceNumber : 0;
-        const auto callbackResult = mnl_cb_run(m_buffer.data(), receiveResult, seqNo, m_portid,
-                                               &NetworkMonitor::dispatchMnMessageCallbackToSelf, this);
-        if (callbackResult == MNL_CB_ERROR)
-        {
+        const auto callbackResult = mnl_cb_run(
+            m_buffer.data(), receiveResult, seqNo, m_portid, &NetworkMonitor::dispatchMnMessageCallbackToSelf, this);
+        if (callbackResult == MNL_CB_ERROR) {
             pwarn("mnl_cb_run");
             break;
         }
-        if (callbackResult == MNL_CB_STOP)
-        {
-            if (isEnumeratingLinks())
-            {
+        if (callbackResult == MNL_CB_STOP) {
+            if (isEnumeratingLinks()) {
                 m_cacheState = CacheState::EnumeratingAddresses;
                 spdlog::debug("Requesting RTM_GETADDR");
                 sendDumpRequest(RTM_GETADDR);
-            }
-            else if (isEnumeratingAddresses())
-            {
+            } else if (isEnumeratingAddresses()) {
                 m_cacheState = CacheState::EnumeratingRoutes;
                 spdlog::debug("Requesting RTM_GETROUTE");
                 sendDumpRequest(RTM_GETROUTE);
-            }
-            else if (isEnumeratingRoutes())
-            {
+            } else if (isEnumeratingRoutes()) {
                 m_cacheState = CacheState::WaitingForChanges;
                 spdlog::debug("Done with enumeration of initial information");
                 spdlog::debug("Tracking changes for {} interfaces", m_trackers.size());
-                if (m_enumerationDoneNotifier.hasWatchers())
-                {
+                if (m_enumerationDoneNotifier.hasWatchers()) {
                     m_enumerationDoneNotifier.notify();
                 }
                 printStatsForNerdsIfEnabled();
                 // run() will restart this loop
                 break;
-            }
-            else
-            {
-                if (m_mnlSocket)
-                {
+            } else {
+                if (m_mnlSocket) {
                     pwarn("Unexpected MNL_CB_STOP");
-                }
-                else
-                {
-                    break; // someone may call stop() while we are notifying watchers
+                } else {
+                    break;  // someone may call stop() while we are notifying watchers
                 }
             }
         }
         printStatsForNerdsIfEnabled();
         notifyChanges();
         // someone may call stop() while we are notifying watchers
-        if (m_mnlSocket)
-        {
+        if (m_mnlSocket) {
             receiveResult = mnl_socket_recvfrom(m_mnlSocket.get(), m_buffer.data(), m_buffer.size());
         }
     }
@@ -325,203 +292,173 @@ void NetworkMonitor::receiveAndProcess()
 
 void NetworkMonitor::sendDumpRequest(uint16_t msgType)
 {
-    nlmsghdr *nlh = mnl_nlmsg_put_header(m_buffer.data());
+    nlmsghdr* nlh = mnl_nlmsg_put_header(m_buffer.data());
     nlh->nlmsg_type = msgType;
     nlh->nlmsg_flags = NLM_F_REQUEST | NLM_F_DUMP;
     nlh->nlmsg_seq = ++m_sequenceNumber;
-    auto *gen = static_cast<rtgenmsg *>(mnl_nlmsg_put_extra_header(nlh, sizeof(struct rtgenmsg)));
+    auto* gen = static_cast<rtgenmsg*>(mnl_nlmsg_put_extra_header(nlh, sizeof(struct rtgenmsg)));
     gen->rtgen_family = AF_UNSPEC;
     mnl_attr_put_u32(nlh, IFLA_EXT_MASK, RTEXT_FILTER_SKIP_STATS);
     auto ret = mnl_socket_sendto(m_mnlSocket.get(), nlh, nlh->nlmsg_len);
-    if (ret < 0)
-    {
+    if (ret < 0) {
         pfatal("mnl_socket_sendto");
     }
     m_stats.packetsSent++;
     m_stats.bytesSent += ret;
 }
 
-auto NetworkMonitor::mnlMessageCallback(const nlmsghdr *n) -> int
+auto NetworkMonitor::mnlMessageCallback(const nlmsghdr* n) -> int
 {
-    if (!m_mnlSocket)
-    {
-        return MNL_CB_STOP; // someone may call stop() while we are processing messages
+    if (!m_mnlSocket) {
+        return MNL_CB_STOP;  // someone may call stop() while we are processing messages
     }
     m_stats.msgsReceived++;
     const auto t = n->nlmsg_type;
-    switch (t)
-    {
-    case RTM_NEWLINK:
-    case RTM_DELLINK: {
-        const auto *ifi = static_cast<const ifinfomsg *>(mnl_nlmsg_get_payload(n));
-        parseLinkMessage(n, ifi);
-    }
-    break;
-    case RTM_NEWADDR:
-    case RTM_DELADDR: {
-        const auto *ifa = static_cast<const ifaddrmsg *>(mnl_nlmsg_get_payload(n));
-        parseAddressMessage(n, ifa);
-    }
-    break;
-    case RTM_NEWROUTE:
-    case RTM_DELROUTE: {
-        const auto *rt = static_cast<const rtmsg *>(mnl_nlmsg_get_payload(n));
-        parseRouteMessage(n, rt);
-    }
-    break;
-    default:
-        spdlog::warn("ignoring unexpected message type: {}", t);
-        break;
+    switch (t) {
+        case RTM_NEWLINK:
+        case RTM_DELLINK: {
+            const auto* ifi = static_cast<const ifinfomsg*>(mnl_nlmsg_get_payload(n));
+            parseLinkMessage(n, ifi);
+        } break;
+        case RTM_NEWADDR:
+        case RTM_DELADDR: {
+            const auto* ifa = static_cast<const ifaddrmsg*>(mnl_nlmsg_get_payload(n));
+            parseAddressMessage(n, ifa);
+        } break;
+        case RTM_NEWROUTE:
+        case RTM_DELROUTE: {
+            const auto* rt = static_cast<const rtmsg*>(mnl_nlmsg_get_payload(n));
+            parseRouteMessage(n, rt);
+        } break;
+        default:
+            spdlog::warn("ignoring unexpected message type: {}", t);
+            break;
     }
     return MNL_CB_OK;
 }
 
-auto NetworkMonitor::ensureNameCurrent(uint32_t ifIndex, const std::optional<std::string> &name)
-    -> NetworkInterfaceStatusTracker &
+auto NetworkMonitor::ensureNameCurrent(uint32_t ifIndex, const std::optional<std::string>& name)
+    -> NetworkInterfaceStatusTracker&
 {
     const auto before = m_trackers.size();
-    auto &cacheEntry = m_trackers[ifIndex];
+    auto& cacheEntry = m_trackers[ifIndex];
 
     // Sometimes interfaces are renamed, account for that
-    if (name.has_value())
-    {
+    if (name.has_value()) {
         cacheEntry.setName(name.value());
     }
-    if (before != m_trackers.size() || cacheEntry.isDirty(DirtyFlag::NameChanged))
-    {
+    if (before != m_trackers.size() || cacheEntry.isDirty(DirtyFlag::NameChanged)) {
         notifyInterfacesSnapshot();
         cacheEntry.clearFlag(DirtyFlag::NameChanged);
     }
     return cacheEntry;
 }
 
-void NetworkMonitor::parseLinkMessage(const nlmsghdr *nlhdr, const ifinfomsg *ifi)
+void NetworkMonitor::parseLinkMessage(const nlmsghdr* nlhdr, const ifinfomsg* ifi)
 {
     m_stats.linkMessagesSeen++;
     const auto attributes = Attributes::parse(nlhdr, sizeof(*ifi), IFLA_MAX, m_stats.seenAttributes);
     const auto itfName = attributes.getString(IFLA_IFNAME);
-    if (ifi->ifi_type != ARPHRD_ETHER && ifi->ifi_type != ARPHRD_IEEE80211)
-    {
-        if (!m_runtimeOptions.test(RuntimeFlag::IncludeNonIeee802))
-        {
-            spdlog::debug("Discarding interface {}: {} (use --include_non_ieee802 to include)", ifi->ifi_index,
+    if (ifi->ifi_type != ARPHRD_ETHER && ifi->ifi_type != ARPHRD_IEEE80211) {
+        if (!m_runtimeOptions.test(RuntimeFlag::IncludeNonIeee802)) {
+            spdlog::debug("Discarding interface {}: {} (use --include_non_ieee802 to include)",
+                          ifi->ifi_index,
                           itfName.value_or("unknown"));
             m_stats.msgsDiscarded++;
             return;
         }
         spdlog::trace("Including non-IEEE 802.X interface {}: {}", ifi->ifi_index, itfName.value_or("unknown"));
     }
-    if (nlhdr->nlmsg_type == RTM_DELLINK)
-    {
+    if (nlhdr->nlmsg_type == RTM_DELLINK) {
         spdlog::trace("removing interface with index {}", ifi->ifi_index);
         m_trackers.erase(ifi->ifi_index);
         notifyInterfacesSnapshot();
         return;
     }
 
-    auto &cacheEntry = ensureNameCurrent(ifi->ifi_index, itfName);
+    auto& cacheEntry = ensureNameCurrent(ifi->ifi_index, itfName);
     const auto operationalStateOpt = attributes.getU8(IFLA_OPERSTATE);
-    if (operationalStateOpt.has_value())
-    {
+    if (operationalStateOpt.has_value()) {
         cacheEntry.setOperationalState(static_cast<OperationalState>(operationalStateOpt.value()));
     }
 
     const auto macAddressOpt = attributes.getEthernetAddress(IFLA_ADDRESS);
-    if (macAddressOpt.has_value())
-    {
+    if (macAddressOpt.has_value()) {
         cacheEntry.setMacAddress(macAddressOpt.value());
-    }
-    else
-    {
+    } else {
         spdlog::warn("Interface {}: {} has no MAC address", ifi->ifi_index, cacheEntry.name());
     }
 
     const auto broadcastAddressOpt = attributes.getEthernetAddress(IFLA_BROADCAST);
-    if (broadcastAddressOpt.has_value())
-    {
+    if (broadcastAddressOpt.has_value()) {
         cacheEntry.setBroadcastAddress(broadcastAddressOpt.value());
-    }
-    else
-    {
+    } else {
         spdlog::warn("Interface {}: {} has no broadcast address", ifi->ifi_index, cacheEntry.name());
     }
 }
 
-void NetworkMonitor::parseAddressMessage(const nlmsghdr *nlhdr, const ifaddrmsg *ifa)
+void NetworkMonitor::parseAddressMessage(const nlmsghdr* nlhdr, const ifaddrmsg* ifa)
 {
     m_stats.addressMessagesSeen++;
-    if (m_trackers.find(ifa->ifa_index) == m_trackers.cend())
-    {
+    if (m_trackers.find(ifa->ifa_index) == m_trackers.cend()) {
         m_stats.msgsDiscarded++;
         return;
     }
-    if (m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV4) && ifa->ifa_family != AF_INET)
-    {
+    if (m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV4) && ifa->ifa_family != AF_INET) {
         m_stats.msgsDiscarded++;
         return;
     }
 
-    if (m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV6) && ifa->ifa_family != AF_INET6)
-    {
+    if (m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV6) && ifa->ifa_family != AF_INET6) {
         m_stats.msgsDiscarded++;
         return;
     }
 
     const auto attributes = Attributes::parse(nlhdr, sizeof(*ifa), IFA_MAX, m_stats.seenAttributes);
 
-    uint32_t flags = ifa->ifa_flags; // will be overwritten if IFA_FLAGS is present
+    uint32_t flags = ifa->ifa_flags;  // will be overwritten if IFA_FLAGS is present
     ip::Address address;
     ip::Address broadcast;
-    uint8_t prot = IFAPROT_UNSPEC; // will be overwritten if IFA_PROTO is present
+    uint8_t prot = IFAPROT_UNSPEC;  // will be overwritten if IFA_PROTO is present
 
-    auto &cacheEntry = ensureNameCurrent(ifa->ifa_index, attributes.getString(IFA_LABEL));
+    auto& cacheEntry = ensureNameCurrent(ifa->ifa_index, attributes.getString(IFA_LABEL));
     const auto flagsOpt = attributes.getU32(IFA_FLAGS);
-    if (flagsOpt.has_value())
-    {
+    if (flagsOpt.has_value()) {
         flags = flagsOpt.value();
     }
     const auto protoOpt = attributes.getU8(IFA_PROTO);
-    if (protoOpt.has_value())
-    {
+    if (protoOpt.has_value()) {
         prot = protoOpt.value();
     }
     const auto broadcastV4Opt = attributes.getIpV4Address(IFA_BROADCAST);
-    if (broadcastV4Opt.has_value())
-    {
+    if (broadcastV4Opt.has_value()) {
         broadcast = broadcastV4Opt.value();
     }
     const auto localV4Opt = attributes.getIpV4Address(IFA_LOCAL);
-    if (localV4Opt.has_value())
-    {
+    if (localV4Opt.has_value()) {
         address = localV4Opt.value();
     }
     const auto addressV6Opt = attributes.getIpV6Address(IFA_ADDRESS);
-    if (addressV6Opt.has_value())
-    {
+    if (addressV6Opt.has_value()) {
         address = addressV6Opt.value();
     }
-    const network::Address networkAddress{
+    const network::Address networkAddress {
         address, broadcast, ifa->ifa_prefixlen, network::fromRtnlScope(ifa->ifa_scope), flags, prot};
-    if (nlhdr->nlmsg_type == RTM_NEWADDR)
-    {
+    if (nlhdr->nlmsg_type == RTM_NEWADDR) {
         cacheEntry.addNetworkAddress(networkAddress);
-    }
-    else if (nlhdr->nlmsg_type == RTM_DELADDR)
-    {
+    } else if (nlhdr->nlmsg_type == RTM_DELADDR) {
         cacheEntry.removeNetworkAddress(networkAddress);
     }
 }
 
-void NetworkMonitor::parseRouteMessage(const nlmsghdr *nlhdr, const rtmsg *rtm)
+void NetworkMonitor::parseRouteMessage(const nlmsghdr* nlhdr, const rtmsg* rtm)
 {
     m_stats.routeMessagesSeen++;
-    if (rtm->rtm_family != AF_INET)
-    {
+    if (rtm->rtm_family != AF_INET) {
         m_stats.msgsDiscarded++;
         return;
     }
-    if (m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV6) && rtm->rtm_family != AF_INET6)
-    {
+    if (m_runtimeOptions.test(RuntimeFlag::PreferredFamilyV6) && rtm->rtm_family != AF_INET6) {
         m_stats.msgsDiscarded++;
         return;
     }
@@ -530,24 +467,18 @@ void NetworkMonitor::parseRouteMessage(const nlmsghdr *nlhdr, const rtmsg *rtm)
     auto ifIndexOpt = attributes.getU32(RTA_OIF);
     auto gatewayV4Opt = attributes.getIpV4Address(RTA_GATEWAY);
 
-    if (nlhdr->nlmsg_type == RTM_DELROUTE)
-    {
-        if (ifIndexOpt.has_value())
-        {
-            if ((rtm->rtm_flags & RTNH_F_LINKDOWN) != 0U)
-            {
+    if (nlhdr->nlmsg_type == RTM_DELROUTE) {
+        if (ifIndexOpt.has_value()) {
+            if ((rtm->rtm_flags & RTNH_F_LINKDOWN) != 0U) {
                 auto itr = m_trackers.find(ifIndexOpt.value());
-                if (itr != m_trackers.end())
-                {
+                if (itr != m_trackers.end()) {
                     itr->second.clearGatewayAddress(GatewayClearReason::LinkDown);
                 }
                 return;
             }
-            if (gatewayV4Opt.has_value())
-            {
+            if (gatewayV4Opt.has_value()) {
                 auto itr = m_trackers.find(ifIndexOpt.value());
-                if (itr != m_trackers.end())
-                {
+                if (itr != m_trackers.end()) {
                     itr->second.clearGatewayAddress(GatewayClearReason::RouteDeleted);
                 }
             }
@@ -555,11 +486,9 @@ void NetworkMonitor::parseRouteMessage(const nlmsghdr *nlhdr, const rtmsg *rtm)
         return;
     }
 
-    if (ifIndexOpt.has_value() && gatewayV4Opt.has_value())
-    {
+    if (ifIndexOpt.has_value() && gatewayV4Opt.has_value()) {
         const auto itr = m_trackers.find(ifIndexOpt.value());
-        if (itr != m_trackers.end())
-        {
+        if (itr != m_trackers.end()) {
             itr->second.setGatewayAddress(gatewayV4Opt.value());
         }
     }
@@ -567,14 +496,14 @@ void NetworkMonitor::parseRouteMessage(const nlmsghdr *nlhdr, const rtmsg *rtm)
 
 void NetworkMonitor::printStatsForNerdsIfEnabled()
 {
-    if (isEnumerating() || !m_runtimeOptions.test(RuntimeFlag::StatsForNerds))
-    {
+    if (isEnumerating() || !m_runtimeOptions.test(RuntimeFlag::StatsForNerds)) {
         return;
     }
     spdlog::info("--------------- Stats for nerds -----------------");
-    spdlog::info("uptime    {}ms", std::chrono::duration_cast<std::chrono::milliseconds>(
-                                       std::chrono::steady_clock::now() - m_stats.startTime)
-                                       .count());
+    spdlog::info(
+        "uptime    {}ms",
+        std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - m_stats.startTime)
+            .count());
     spdlog::info("sent      {} bytes in {} packets", m_stats.bytesSent, m_stats.packetsSent);
     spdlog::info("received  {} bytes in {} packets", m_stats.bytesReceived, m_stats.packetsReceived);
     spdlog::info("received  {} rtnl messages", m_stats.msgsReceived);
@@ -586,46 +515,39 @@ void NetworkMonitor::printStatsForNerdsIfEnabled()
     spdlog::info("          {} route messages", m_stats.routeMessagesSeen);
 
     spdlog::info("----------- Interface details in cache ----------");
-    for (const auto &c : m_trackers)
-    {
+    for (const auto& c : m_trackers) {
         spdlog::info(c.second);
     }
     spdlog::info("-------------------------------------------------");
 }
 
-auto NetworkMonitor::dispatchMnMessageCallbackToSelf(const nlmsghdr *n, void *self) -> int
+auto NetworkMonitor::dispatchMnMessageCallbackToSelf(const nlmsghdr* n, void* self) -> int
 {
-    return static_cast<NetworkMonitor *>(self)->mnlMessageCallback(n);
+    return static_cast<NetworkMonitor*>(self)->mnlMessageCallback(n);
 }
 
 void NetworkMonitor::notifyChanges()
 {
-    for (auto &[index, tracker] : m_trackers)
-    {
+    for (auto& [index, tracker] : m_trackers) {
         spdlog::trace("checking {} for changes", tracker);
-        if (m_operationalStateNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::OperationalStateChanged))
-        {
-            m_operationalStateNotifier.notify(network::Interface{index, tracker.name()}, tracker.operationalState());
+        if (m_operationalStateNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::OperationalStateChanged)) {
+            m_operationalStateNotifier.notify(network::Interface {index, tracker.name()}, tracker.operationalState());
             tracker.clearFlag(DirtyFlag::OperationalStateChanged);
         }
-        if (m_networkAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::NetworkAddressesChanged))
-        {
-            m_networkAddressNotifier.notify(network::Interface{index, tracker.name()}, tracker.networkAddresses());
+        if (m_networkAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::NetworkAddressesChanged)) {
+            m_networkAddressNotifier.notify(network::Interface {index, tracker.name()}, tracker.networkAddresses());
             tracker.clearFlag(DirtyFlag::NetworkAddressesChanged);
         }
-        if (m_gatewayAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::GatewayAddressChanged))
-        {
-            m_gatewayAddressNotifier.notify(network::Interface{index, tracker.name()}, tracker.gatewayAddress());
+        if (m_gatewayAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::GatewayAddressChanged)) {
+            m_gatewayAddressNotifier.notify(network::Interface {index, tracker.name()}, tracker.gatewayAddress());
             tracker.clearFlag(DirtyFlag::GatewayAddressChanged);
         }
-        if (m_macAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::MacAddressChanged))
-        {
-            m_macAddressNotifier.notify(network::Interface{index, tracker.name()}, tracker.macAddress());
+        if (m_macAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::MacAddressChanged)) {
+            m_macAddressNotifier.notify(network::Interface {index, tracker.name()}, tracker.macAddress());
             tracker.clearFlag(DirtyFlag::MacAddressChanged);
         }
-        if (m_broadcastAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::BroadcastAddressChanged))
-        {
-            m_broadcastAddressNotifier.notify(network::Interface{index, tracker.name()}, tracker.broadcastAddress());
+        if (m_broadcastAddressNotifier.hasWatchers() && tracker.isDirty(DirtyFlag::BroadcastAddressChanged)) {
+            m_broadcastAddressNotifier.notify(network::Interface {index, tracker.name()}, tracker.broadcastAddress());
             tracker.clearFlag(DirtyFlag::BroadcastAddressChanged);
         }
     }
@@ -633,8 +555,7 @@ void NetworkMonitor::notifyChanges()
 
 void NetworkMonitor::notifyInterfacesSnapshot()
 {
-    if (m_interfacesNotifier.hasWatchers())
-    {
+    if (m_interfacesNotifier.hasWatchers()) {
         m_interfacesNotifier.notify(getInterfacesSnapshot());
     }
 }
@@ -642,14 +563,12 @@ void NetworkMonitor::notifyInterfacesSnapshot()
 auto NetworkMonitor::getInterfacesSnapshot() const -> Interfaces
 {
     Interfaces intfs;
-    for (const auto &[idx, tracker] : m_trackers)
-    {
-        if (tracker.hasName())
-        {
+    for (const auto& [idx, tracker] : m_trackers) {
+        if (tracker.hasName()) {
             intfs.emplace(idx, tracker.name());
         }
     }
     return intfs;
 }
 
-} // namespace monkas::monitor
+}  // namespace monkas::monitor

--- a/src/network/Address.cpp
+++ b/src/network/Address.cpp
@@ -1,19 +1,24 @@
+#include <ostream>
+
 #include <linux/if_addr.h>
 #include <linux/rtnetlink.h>
 #include <network/Address.hpp>
-#include <ostream>
 
 namespace monkas::network
 {
 
-Address::Address(const ip::Address &address, const ip::Address &broadcast, uint8_t prefixLen, Scope scope,
-                 uint32_t flags, uint8_t proto)
-    : m_ip{address}
-    , m_brd{broadcast}
-    , m_prefixlen{prefixLen}
-    , m_scope{scope}
-    , m_flags{flags}
-    , m_prot{proto}
+Address::Address(const ip::Address& address,
+                 const ip::Address& broadcast,
+                 uint8_t prefixLen,
+                 Scope scope,
+                 uint32_t flags,
+                 uint8_t proto)
+    : m_ip {address}
+    , m_brd {broadcast}
+    , m_prefixlen {prefixLen}
+    , m_scope {scope}
+    , m_flags {flags}
+    , m_prot {proto}
 {
 }
 
@@ -47,12 +52,12 @@ auto Address::isMappedV4() const -> bool
     return m_ip.isMappedV4();
 }
 
-auto Address::ip() const -> const ip::Address &
+auto Address::ip() const -> const ip::Address&
 {
     return m_ip;
 }
 
-auto Address::broadcast() const -> const ip::Address &
+auto Address::broadcast() const -> const ip::Address&
 {
     return m_brd;
 }
@@ -77,26 +82,21 @@ auto Address::proto() const -> uint8_t
     return m_prot;
 }
 
-auto Address::operator<=>(const Address &other) const -> std::strong_ordering
+auto Address::operator<=>(const Address& other) const -> std::strong_ordering
 {
-    if (auto cmp = m_ip <=> other.m_ip; cmp != 0)
-    {
+    if (auto cmp = m_ip <=> other.m_ip; cmp != 0) {
         return cmp;
     }
-    if (auto cmp = m_brd <=> other.m_brd; cmp != 0)
-    {
+    if (auto cmp = m_brd <=> other.m_brd; cmp != 0) {
         return cmp;
     }
-    if (auto cmp = m_prefixlen <=> other.m_prefixlen; cmp != 0)
-    {
+    if (auto cmp = m_prefixlen <=> other.m_prefixlen; cmp != 0) {
         return cmp;
     }
-    if (auto cmp = m_scope <=> other.m_scope; cmp != 0)
-    {
+    if (auto cmp = m_scope <=> other.m_scope; cmp != 0) {
         return cmp;
     }
-    if (auto cmp = m_flags <=> other.m_flags; cmp != 0)
-    {
+    if (auto cmp = m_flags <=> other.m_flags; cmp != 0) {
         return cmp;
     }
     return m_prot <=> other.m_prot;
@@ -104,78 +104,73 @@ auto Address::operator<=>(const Address &other) const -> std::strong_ordering
 
 auto fromRtnlScope(uint8_t rtnlScope) -> Scope
 {
-    switch (rtnlScope)
-    {
-    case RT_SCOPE_SITE:
-        return Scope::Site;
-    case RT_SCOPE_LINK:
-        return Scope::Link;
-    case RT_SCOPE_HOST:
-        return Scope::Host;
-    case RT_SCOPE_NOWHERE:
-        return Scope::Nowhere;
-    case RT_SCOPE_UNIVERSE:
-    default:
-        return Scope::Global;
+    switch (rtnlScope) {
+        case RT_SCOPE_SITE:
+            return Scope::Site;
+        case RT_SCOPE_LINK:
+            return Scope::Link;
+        case RT_SCOPE_HOST:
+            return Scope::Host;
+        case RT_SCOPE_NOWHERE:
+            return Scope::Nowhere;
+        case RT_SCOPE_UNIVERSE:
+        default:
+            return Scope::Global;
     }
 }
 
-auto operator<<(std::ostream &o, Scope a) -> std::ostream &
+auto operator<<(std::ostream& o, Scope a) -> std::ostream&
 {
-    switch (a)
-    {
-    case Scope::Site:
-        o << "site";
-        break;
-    case Scope::Link:
-        o << "link";
-        break;
-    case Scope::Host:
-        o << "host";
-        break;
-    case Scope::Nowhere:
-        o << "nowhere";
-        break;
-    case Scope::Global:
-    default:
-        o << "global";
-        break;
+    switch (a) {
+        case Scope::Site:
+            o << "site";
+            break;
+        case Scope::Link:
+            o << "link";
+            break;
+        case Scope::Host:
+            o << "host";
+            break;
+        case Scope::Nowhere:
+            o << "nowhere";
+            break;
+        case Scope::Global:
+        default:
+            o << "global";
+            break;
     }
     return o;
 }
 
-auto operator<<(std::ostream &o, const Address &a) -> std::ostream &
+auto operator<<(std::ostream& o, const Address& a) -> std::ostream&
 {
     o << a.family() << " " << a.ip() << "/" << static_cast<int>(a.prefixLength());
     o << " scope " << a.scope();
-    if (a.broadcast())
-    {
+    if (a.broadcast()) {
         o << " brd " << a.broadcast();
     }
     // TODO: to readable
-    if (a.flags() != 0U)
-    {
+    if (a.flags() != 0U) {
         o << " f 0x" << std::hex << a.flags() << std::dec;
     }
-    switch (a.proto())
-    {
-    case IFAPROT_UNSPEC:
-        break;
-    case IFAPROT_KERNEL_LO:
-        o << " kernel_lo";
-        break;
-    case IFAPROT_KERNEL_RA:
-        o << " kernel_ra";
-        break;
-    case IFAPROT_KERNEL_LL:
-        o << " kernel_ll";
-        break;
-    default:
-        o << " prot unknown: " << static_cast<int>(a.proto());
-        break;
+    switch (a.proto()) {
+        case IFAPROT_UNSPEC:
+            break;
+        case IFAPROT_KERNEL_LO:
+            o << " kernel_lo";
+            break;
+        case IFAPROT_KERNEL_RA:
+            o << " kernel_ra";
+            break;
+        case IFAPROT_KERNEL_LL:
+            o << " kernel_ll";
+            break;
+        default:
+            o << " prot unknown: " << static_cast<int>(a.proto());
+            break;
     }
 
     return o;
 }
 
-} // namespace monkas::network
+}  // namespace monkas::network

--- a/src/network/Address.test.cpp
+++ b/src/network/Address.test.cpp
@@ -11,18 +11,17 @@ using namespace monkas::network;
 
 TEST_SUITE("[network::Address]")
 {
-
-    Scope scope{Scope::Global};
-    std::array<uint8_t, 6> some_hw_addr{1, 2, 3, 4, 5, 0x1A};
-    std::array<uint8_t, 4> some_ipv4{192, 168, 17, 1};
-    std::array<uint8_t, 4> some_bcast{192, 168, 17, 255};
+    Scope scope {Scope::Global};
+    std::array<uint8_t, 6> some_hw_addr {1, 2, 3, 4, 5, 0x1A};
+    std::array<uint8_t, 4> some_ipv4 {192, 168, 17, 1};
+    std::array<uint8_t, 4> some_bcast {192, 168, 17, 255};
 
     const auto someV4 = ip::Address::fromBytes(some_ipv4);
     const auto someBcastV4 = ip::Address::fromBytes(some_bcast);
     const auto someV6 = ip::Address::fromString("2001:db8::1");
-    const Address addrV6{someV6, someBcastV4, 24, scope, 5, 0};
-    const Address addrV4{someV4, someBcastV4, 24, scope, 10, 1};
-    const Address defaultAddress{};
+    const Address addrV6 {someV6, someBcastV4, 24, scope, 5, 0};
+    const Address addrV4 {someV4, someBcastV4, 24, scope, 10, 1};
+    const Address defaultAddress {};
 
     TEST_CASE("operator bool")
     {
@@ -65,13 +64,13 @@ TEST_SUITE("[network::Address]")
     TEST_CASE("ip")
     {
         CHECK(addrV4.ip() == someV4);
-        CHECK(defaultAddress.ip() == ip::Address{});
+        CHECK(defaultAddress.ip() == ip::Address {});
     }
 
     TEST_CASE("broadcast")
     {
         CHECK(addrV4.broadcast() == someBcastV4);
-        CHECK(defaultAddress.broadcast() == ip::Address{});
+        CHECK(defaultAddress.broadcast() == ip::Address {});
     }
 
     TEST_CASE("prefixLength")
@@ -123,4 +122,4 @@ TEST_SUITE("[network::Address]")
 }
 
 // NOLINTEND(*)
-} // namespace
+}  // namespace

--- a/src/network/Interface.cpp
+++ b/src/network/Interface.cpp
@@ -1,18 +1,19 @@
-#include <network/Interface.hpp>
 #include <ostream>
+
+#include <network/Interface.hpp>
 
 namespace monkas::network
 {
 
 Interface::Interface(uint32_t index, std::string name)
-    : m_index{index}
-    , m_name{std::move(name)}
+    : m_index {index}
+    , m_name {std::move(name)}
 {
 }
 
-auto operator<<(std::ostream &os, const Interface &iface) -> std::ostream &
+auto operator<<(std::ostream& os, const Interface& iface) -> std::ostream&
 {
     return os << iface.index() << ": " << iface.name() << ":";
 }
 
-} // namespace monkas::network
+}  // namespace monkas::network

--- a/src/watchable/Watchable.test.cpp
+++ b/src/watchable/Watchable.test.cpp
@@ -1,7 +1,8 @@
-#include <doctest/doctest.h>
 #include <memory>
 #include <stdexcept>
 #include <utility>
+
+#include <doctest/doctest.h>
 #include <watchable/Watchable.hpp>
 
 namespace
@@ -51,15 +52,16 @@ TEST_CASE("Watchable tests")
     SUBCASE("unregistered watcher during notify is not called when notifying")
     {
         auto u = std::make_shared<Watchable<int>::Token>();
-        std::ignore = watchable.addWatcher([&watchable, &lastA, u](int x) {
-            if (lastA == 0)
+        std::ignore = watchable.addWatcher(
+            [&watchable, &lastA, u](int x)
             {
-                watchable.removeWatcher(*u);
-                // remove twice to check that it is safe
-                watchable.removeWatcher(*u);
-            }
-            lastA = x;
-        });
+                if (lastA == 0) {
+                    watchable.removeWatcher(*u);
+                    // remove twice to check that it is safe
+                    watchable.removeWatcher(*u);
+                }
+                lastA = x;
+            });
         *u = watchable.addWatcher(assignToLastB);
 
         watchable.notify(5);
@@ -87,4 +89,4 @@ TEST_CASE("Watchable tests")
 
 TEST_SUITE_END();
 // NOLINTEND(*)
-} // namespace
+}  // namespace


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Standardized code formatting across all source, header, and test files for improved readability and consistency.
  - Updated spacing, brace placement, include order, and alignment throughout the codebase.
  - Revised `.clang-format` configuration to enforce new formatting rules and style guidelines.

- **Chores**
  - Reformatted code and tests to comply with the updated style configuration.
  - No changes to application logic, functionality, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->