### PR TITLE
refactor(ethernet): Remove validity tracking from Address class

### DIFF
--- a/include/monkas/ethernet/Address.hpp
+++ b/include/monkas/ethernet/Address.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <array>
-#include <compare>
 #include <cstdint>
 #include <iosfwd>
 
@@ -17,19 +16,8 @@ class Address : public std::array<uint8_t, ADDR_LEN>
     Address();
     [[nodiscard]] auto toString() const -> std::string;
 
-    /**
-     * @return true if actually constructed from bytes
-     */
-    explicit operator bool() const;
-
     static auto fromBytes(const uint8_t* bytes, size_type len) -> Address;
     static auto fromBytes(const std::array<uint8_t, ADDR_LEN>& bytes) -> Address;
-
-    [[nodiscard]] auto operator<=>(const Address&) const -> std::strong_ordering;
-    [[nodiscard]] auto operator==(const Address&) const -> bool;
-
-  private:
-    bool m_isValid {false};
 };
 
 auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;

--- a/src/ethernet/Address.cpp
+++ b/src/ethernet/Address.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <cstdio>
 #include <ostream>
 
 #include <ethernet/Address.hpp>
@@ -19,7 +18,6 @@ auto Address::fromBytes(const uint8_t* bytes, size_type len) -> Address
     }
     Address r;
     std::copy_n(bytes, len, r.begin());
-    r.m_isValid = true;
     return r;
 }
 
@@ -30,9 +28,6 @@ auto Address::fromBytes(const std::array<uint8_t, ADDR_LEN>& bytes) -> Address
 
 auto Address::toString() const -> std::string
 {
-    if (!m_isValid) {
-        return {"Invalid"};
-    }
     constexpr auto LEN = 17;  // 6*2 hex digits + 5 colons
     std::array<char, LEN> buf {};
     int idx = 0;
@@ -48,33 +43,6 @@ auto Address::toString() const -> std::string
         i++;
     }
     return {buf.data(), buf.size()};
-}
-
-Address::operator bool() const
-{
-    return m_isValid;
-}
-
-auto Address::operator<=>(const Address& other) const -> std::strong_ordering
-{
-    if (!m_isValid && !other.m_isValid) {
-        return std::strong_ordering::equal;
-    }
-    if (!m_isValid) {
-        return std::strong_ordering::less;
-    }
-    if (!other.m_isValid) {
-        return std::strong_ordering::greater;
-    }
-    return std::lexicographical_compare_three_way(begin(), end(), other.begin(), other.end());
-}
-
-auto Address::operator==(const Address& other) const -> bool
-{
-    if (!m_isValid || !other.m_isValid) {
-        return false;
-    }
-    return std::equal(begin(), end(), other.begin());
 }
 
 auto operator<<(std::ostream& o, const Address& a) -> std::ostream&

--- a/src/ethernet/Address.test.cpp
+++ b/src/ethernet/Address.test.cpp
@@ -13,39 +13,26 @@ TEST_SUITE("[ethernet::Address]")
 
     const auto someAddress = Address::fromBytes(bytesSome);
     const auto nullAddress = Address::fromBytes(bytesNull);
-    const auto defaultAddress = Address {};
 
     TEST_CASE("toString")
     {
-        CHECK(defaultAddress.toString() == "Invalid");
         CHECK(nullAddress.toString() == "00:00:00:00:00:00");
         CHECK(someAddress.toString() == "01:02:03:04:05:1a");
     }
 
-    TEST_CASE("operator bool")
-    {
-        CHECK(!defaultAddress);
-        CHECK(nullAddress);
-        CHECK(someAddress);
-    }
-
     TEST_CASE("operator ==")
     {
-        CHECK_FALSE(defaultAddress == nullAddress);
         CHECK(someAddress == someAddress);
+        CHECK(nullAddress == nullAddress);
     }
 
     TEST_CASE("operator !=")
     {
-        CHECK(defaultAddress != nullAddress);
-        CHECK(defaultAddress != someAddress);
         CHECK(nullAddress != someAddress);
     }
 
     TEST_CASE("operator <")
     {
-        CHECK(defaultAddress < nullAddress);
-        CHECK(defaultAddress < someAddress);
         CHECK(nullAddress < someAddress);
     }
 }

--- a/src/monitor/NetworkInterfaceStatusTracker.cpp
+++ b/src/monitor/NetworkInterfaceStatusTracker.cpp
@@ -310,12 +310,8 @@ auto operator<<(std::ostream& o, const DirtyFlags& d) -> std::ostream&
 auto operator<<(std::ostream& o, const NetworkInterfaceStatusTracker& s) -> std::ostream&
 {
     o << s.name();
-    if (s.m_macAddress) {
-        o << " mac " << s.m_macAddress;
-    }
-    if (s.m_broadcastAddress) {
-        o << " brd " << s.m_broadcastAddress;
-    }
+    o << " mac " << s.m_macAddress;
+    o << " brd " << s.m_broadcastAddress;
     if (!s.m_networkAddresses.empty()) {
         o << " [";
         bool first = true;


### PR DESCRIPTION
Closes #101 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Address formatting now always displays the address, removing previous "Invalid" output for certain cases.
  - MAC and broadcast addresses are always shown in network interface status output, regardless of state.

- **Tests**
  - Simplified and updated tests to remove checks for address validity and related comparison logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->