### PR TITLE
chore: Split network buffer into send/receive buffers and add dump request retry method

### DIFF
--- a/include/monkas/monitor/NetworkMonitor.hpp
+++ b/include/monkas/monitor/NetworkMonitor.hpp
@@ -127,6 +127,7 @@ class NetworkMonitor
 
     /* @note: only one such request can be in progress until the reply is received */
     void sendDumpRequest(uint16_t msgType);
+    void retryLastDumpRequest();
 
     auto ensureNameCurrent(uint32_t ifIndex, const std::optional<std::string>& name) -> NetworkInterfaceStatusTracker&;
 
@@ -155,7 +156,8 @@ class NetworkMonitor
     [[nodiscard]] auto getInterfacesSnapshot() const -> Interfaces;
 
     std::unique_ptr<mnl_socket, int (*)(mnl_socket*)> m_mnlSocket;
-    std::vector<uint8_t> m_buffer;
+    std::vector<uint8_t> m_receiveBuffer;
+    std::vector<uint8_t> m_sendBuffer;
     bool m_running {false};
     uint32_t m_portid {};
     uint32_t m_sequenceNumber {};


### PR DESCRIPTION
Closes #48 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to retry the last network data request automatically if a protocol error occurs during data enumeration.

- **Improvements**
  - Enhanced error handling for network data retrieval.
  - Improved performance and reliability by separating send and receive data buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->