### PR TITLE
chore(ci): Add dynamic check_name input to JUnit Report step in GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,7 +55,7 @@ jobs:
     name: ${{ matrix.toolchain.name }}
     permissions:
       pull-requests: write # retain for PR operations
-      checks: write        # required for action-junit-report annotations
+      checks: write # required for action-junit-report annotations
     strategy:
       fail-fast: false
       matrix:
@@ -175,3 +175,4 @@ jobs:
           fail_on_parse_error: true
           require_tests: true
           include_passed: true
+          check_name: "${{ matrix.toolchain.name }} JUnit Report"

--- a/external/doctest/CMakeLists.txt
+++ b/external/doctest/CMakeLists.txt
@@ -30,7 +30,7 @@ target_compile_features(doctest_exe PRIVATE cxx_std_20)
 add_test(
     NAME doctest
     COMMAND
-        $<TARGET_FILE:doctest_exe> --no-version --reporters=junit --no-breaks --no-colors --out=junit.xml
+        $<TARGET_FILE:doctest_exe> --reporters=junit --out=junit.xml
 )
 
 # HACK(hrzgnm): disable analyzer checks on doctest targets


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the GitHub Actions workflow to include a dynamic name for the JUnit Report step based on the current toolchain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->