### PR TITLE
refactor: Add type aliases for address byte arrays and refactor Address classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ build*/
 
 # IDE configuration
 .vscode/*
-
+.idea
 
 # test results 
 junit.xml

--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -40,8 +40,9 @@ auto main(int argc, char* argv[]) -> int
     gflags::SetUsageMessage("<flags>\n");
     gflags::ParseCommandLineFlags(&argc, &argv, true);
 
-    std::transform(FLAGS_log_level.begin(), FLAGS_log_level.end(), FLAGS_log_level.begin(), ::tolower);
-    if (auto level = spdlog::level::from_str(FLAGS_log_level); level == spdlog::level::off && FLAGS_log_level != "off")
+    std::ranges::transform(FLAGS_log_level, FLAGS_log_level.begin(), ::tolower);
+    if (const auto level = spdlog::level::from_str(FLAGS_log_level);
+        level == spdlog::level::off && FLAGS_log_level != "off")
     {
         SPDLOG_ERROR("invalid log level '{}', using 'info' instead", FLAGS_log_level);
         spdlog::set_level(spdlog::level::info);

--- a/include/monkas/ethernet/Address.hpp
+++ b/include/monkas/ethernet/Address.hpp
@@ -9,6 +9,7 @@
 namespace monkas::ethernet
 {
 constexpr auto ADDR_LEN = 6;
+using EthernetBytes = std::array<uint8_t, ADDR_LEN>;
 
 class Address : public std::array<uint8_t, ADDR_LEN>
 {
@@ -16,8 +17,10 @@ class Address : public std::array<uint8_t, ADDR_LEN>
     Address();
     [[nodiscard]] auto toString() const -> std::string;
 
+    static auto fromBytes(const EthernetBytes& bytes) -> Address;
+
+  private:
     static auto fromBytes(const uint8_t* bytes, size_type len) -> Address;
-    static auto fromBytes(const std::array<uint8_t, ADDR_LEN>& bytes) -> Address;
 };
 
 auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;

--- a/include/monkas/ip/Address.hpp
+++ b/include/monkas/ip/Address.hpp
@@ -26,6 +26,9 @@ auto operator<<(std::ostream& o, Family a) -> std::ostream&;
 constexpr auto IPV6_ADDR_LEN = 16;
 constexpr auto IPV4_ADDR_LEN = 4;
 
+using IpV4Bytes = std::array<uint8_t, IPV4_ADDR_LEN>;
+using IpV6Bytes = std::array<uint8_t, IPV6_ADDR_LEN>;
+
 class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
 {
   public:
@@ -68,9 +71,8 @@ class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
     [[nodiscard]] auto family() const -> Family;
     [[nodiscard]] auto addressLength() const -> size_type;
 
-    static auto fromBytes(const uint8_t* bytes, size_type len) -> Address;
-    static auto fromBytes(const std::array<uint8_t, IPV4_ADDR_LEN>& bytes) -> Address;
-    static auto fromBytes(const std::array<uint8_t, IPV6_ADDR_LEN>& bytes) -> Address;
+    static auto fromBytes(const IpV4Bytes& bytes) -> Address;
+    static auto fromBytes(const IpV6Bytes& bytes) -> Address;
 
     // overload the one from std::array<uint8_t, IPV6_ADDR_LEN>
     [[nodiscard]] auto operator<=>(const Address& rhs) const noexcept -> std::strong_ordering;
@@ -78,6 +80,7 @@ class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
     [[nodiscard]] auto operator==(const Address& rhs) const noexcept -> bool;
 
   private:
+    static auto fromBytes(const uint8_t* bytes, size_type len) -> Address;
     [[nodiscard]] auto ipv4() const -> uint32_t;
 
     Family m_family {Family::Unspecified};

--- a/src/ethernet/Address.cpp
+++ b/src/ethernet/Address.cpp
@@ -13,15 +13,12 @@ Address::Address()
 
 auto Address::fromBytes(const uint8_t* bytes, size_type len) -> Address
 {
-    if (bytes == nullptr || len != ADDR_LEN) {
-        return {};
-    }
     Address r;
     std::copy_n(bytes, len, r.begin());
     return r;
 }
 
-auto Address::fromBytes(const std::array<uint8_t, ADDR_LEN>& bytes) -> Address
+auto Address::fromBytes(const EthernetBytes& bytes) -> Address
 {
     return fromBytes(bytes.data(), bytes.size());
 }

--- a/src/ip/Address.cpp
+++ b/src/ip/Address.cpp
@@ -245,12 +245,12 @@ auto Address::fromBytes(const uint8_t* bytes, size_type len) -> Address
     return {};
 }
 
-auto Address::fromBytes(const std::array<uint8_t, IPV4_ADDR_LEN>& bytes) -> Address
+auto Address::fromBytes(const IpV4Bytes& bytes) -> Address
 {
     return fromBytes(bytes.data(), bytes.size());
 }
 
-auto Address::fromBytes(const std::array<uint8_t, IPV6_ADDR_LEN>& bytes) -> Address
+auto Address::fromBytes(const IpV6Bytes& bytes) -> Address
 {
     return fromBytes(bytes.data(), bytes.size());
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced explicit type aliases for Ethernet, IPv4, and IPv6 address byte arrays, improving clarity and type safety in address handling.
  - Added public methods to create address objects directly from these byte array types.

- **Refactor**
  - Updated public interfaces to use the new type aliases instead of generic arrays.
  - Streamlined internal logic for address creation and validation.

- **Chores**
  - Updated ignore rules to exclude JetBrains IDE configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->