### PR TITLE
chore: Replace fmt::underlying with std::to_underlying in NetworkInterfaceStatusTracker.cpp

### DIFF
--- a/src/monitor/NetworkInterfaceStatusTracker.cpp
+++ b/src/monitor/NetworkInterfaceStatusTracker.cpp
@@ -34,8 +34,7 @@ auto NetworkInterfaceStatusTracker::hasName() const -> bool
 
 void NetworkInterfaceStatusTracker::touch(DirtyFlag flag)
 {
-    // TODO: use std::to_underlying with c++23
-    const auto idx = fmt::underlying(flag);
+    const auto idx = std::to_underlying(flag);
     if (idx >= m_dirtyFlags.size()) {
         spdlog::error("Invalid dirty flag index: {}", idx);
         return;
@@ -191,7 +190,7 @@ auto NetworkInterfaceStatusTracker::isDirty() const -> bool
 
 auto NetworkInterfaceStatusTracker::isDirty(DirtyFlag flag) const -> bool
 {
-    const auto idx = fmt::underlying(flag);
+    const auto idx = std::to_underlying(flag);
     if (idx >= m_dirtyFlags.size()) {
         spdlog::error("Invalid dirty flag index: {}, returning false", idx);
         return false;
@@ -207,8 +206,7 @@ auto NetworkInterfaceStatusTracker::dirtyFlags() const -> DirtyFlags
 
 void NetworkInterfaceStatusTracker::clearFlag(DirtyFlag flag)
 {
-    // TODO: use std::to_underlying with c++23
-    const auto idx = fmt::underlying(flag);
+    const auto idx = std::to_underlying(flag);
     if (idx >= m_dirtyFlags.size()) {
         spdlog::error("Invalid dirty flag index: {}", idx);
         return;


### PR DESCRIPTION
Closes #54

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated internal handling of enum values to use a standard library feature, with no impact on user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->