### PR TITLE
chore: Refactor ethernet and IP Address classes to use composition over inheritance

### DIFF
--- a/include/monkas/ethernet/Address.hpp
+++ b/include/monkas/ethernet/Address.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <array>
+#include <compare>
 #include <cstdint>
 #include <iosfwd>
 
@@ -8,19 +9,23 @@
 
 namespace monkas::ethernet
 {
-constexpr auto ADDR_LEN = 6;
-using EthernetBytes = std::array<uint8_t, ADDR_LEN>;
 
-class Address : public std::array<uint8_t, ADDR_LEN>
+constexpr auto ADDR_LEN = 6;
+using Bytes = std::array<uint8_t, ADDR_LEN>;
+
+class Address
 {
   public:
     Address();
+    explicit Address(const Bytes& bytes);
+
     [[nodiscard]] auto toString() const -> std::string;
 
-    static auto fromBytes(const EthernetBytes& bytes) -> Address;
+    auto operator<=>(const Address& other) const -> std::strong_ordering;
+    auto operator==(const Address& other) const -> bool = default;
 
   private:
-    static auto fromBytes(const uint8_t* bytes, size_type len) -> Address;
+    Bytes m_bytes;
 };
 
 auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;

--- a/include/monkas/ip/Address.hpp
+++ b/include/monkas/ip/Address.hpp
@@ -60,8 +60,6 @@ class Address
     [[nodiscard]] auto isUniqueLocal() const -> bool;
     [[nodiscard]] auto isLoopback() const -> bool;
     [[nodiscard]] auto isBroadcast() const -> bool;
-    [[nodiscard]] auto isPrivate() const -> bool;
-    [[nodiscard]] auto isDocumentation() const -> bool;
 
     [[nodiscard]] auto ip() const -> const Address&;
     [[nodiscard]] auto broadcast() const -> const Address&;
@@ -72,8 +70,6 @@ class Address
     [[nodiscard]] auto operator==(const Address& rhs) const noexcept -> bool = default;
 
   private:
-    [[nodiscard]] auto ipv4() const -> uint32_t;
-
     Bytes m_bytes;
 };
 

--- a/include/monkas/ip/Address.hpp
+++ b/include/monkas/ip/Address.hpp
@@ -4,7 +4,6 @@
 #include <compare>
 #include <cstdint>
 #include <iosfwd>
-#include <optional>
 #include <string>
 #include <variant>
 

--- a/include/monkas/ip/Address.hpp
+++ b/include/monkas/ip/Address.hpp
@@ -6,6 +6,7 @@
 #include <iosfwd>
 #include <optional>
 #include <string>
+#include <variant>
 
 #include <fmt/format.h>
 #include <fmt/ostream.h>
@@ -28,11 +29,15 @@ constexpr auto IPV4_ADDR_LEN = 4;
 
 using IpV4Bytes = std::array<uint8_t, IPV4_ADDR_LEN>;
 using IpV6Bytes = std::array<uint8_t, IPV6_ADDR_LEN>;
+using Bytes = std::variant<std::monostate, IpV4Bytes, IpV6Bytes>;
 
-class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
+class Address
 {
   public:
     Address();
+    explicit Address(const IpV4Bytes& bytes);
+    explicit Address(const IpV6Bytes& bytes);
+
     [[nodiscard]] auto toString() const -> std::string;
 
     /**
@@ -45,11 +50,11 @@ class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
      */
     explicit operator bool() const;
 
-    [[nodiscard]] auto isV4() const -> bool { return m_family == Family::IPv4; }
+    [[nodiscard]] auto isV4() const -> bool;
 
-    [[nodiscard]] auto isV6() const -> bool { return m_family == Family::IPv6; }
+    [[nodiscard]] auto isV6() const -> bool;
 
-    [[nodiscard]] auto isUnspecified() const -> bool { return m_family == Family::Unspecified; }
+    [[nodiscard]] auto isUnspecified() const -> bool;
 
     [[nodiscard]] auto isMulticast() const -> bool;
     [[nodiscard]] auto isLinkLocal() const -> bool;
@@ -59,29 +64,18 @@ class Address : public std::array<uint8_t, IPV6_ADDR_LEN>
     [[nodiscard]] auto isPrivate() const -> bool;
     [[nodiscard]] auto isDocumentation() const -> bool;
 
-    [[nodiscard]] auto isMappedV4() const -> bool;
-    [[nodiscard]] auto toMappedV4() const -> std::optional<Address>;
-
     [[nodiscard]] auto ip() const -> const Address&;
     [[nodiscard]] auto broadcast() const -> const Address&;
-    [[nodiscard]] auto prefixLength() const -> uint8_t;
 
     [[nodiscard]] auto family() const -> Family;
-    [[nodiscard]] auto addressLength() const -> size_type;
 
-    static auto fromBytes(const IpV4Bytes& bytes) -> Address;
-    static auto fromBytes(const IpV6Bytes& bytes) -> Address;
-
-    // overload the one from std::array<uint8_t, IPV6_ADDR_LEN>
     [[nodiscard]] auto operator<=>(const Address& rhs) const noexcept -> std::strong_ordering;
-    // overload the one from std::array<uint8_t, IPV6_ADDR_LEN>
-    [[nodiscard]] auto operator==(const Address& rhs) const noexcept -> bool;
+    [[nodiscard]] auto operator==(const Address& rhs) const noexcept -> bool = default;
 
   private:
-    static auto fromBytes(const uint8_t* bytes, size_type len) -> Address;
     [[nodiscard]] auto ipv4() const -> uint32_t;
 
-    Family m_family {Family::Unspecified};
+    Bytes m_bytes;
 };
 
 auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;

--- a/include/monkas/network/Address.hpp
+++ b/include/monkas/network/Address.hpp
@@ -41,7 +41,6 @@ class Address
     [[nodiscard]] auto isV4() const -> bool;
     [[nodiscard]] auto isV6() const -> bool;
     [[nodiscard]] auto isUnspecified() const -> bool;
-    [[nodiscard]] auto isMappedV4() const -> bool;
 
     [[nodiscard]] auto ip() const -> const ip::Address&;
     [[nodiscard]] auto broadcast() const -> const ip::Address&;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -19,7 +19,7 @@ target_compile_definitions(${TARGET_NAME} PUBLIC SPDLOG_FMT_EXTERNAL)
 
 target_compile_features(${TARGET_NAME} PUBLIC cxx_std_23)
 
-target_include_directories(${TARGET_NAME} PUBLIC ${PUBLIC_INCLUDE_DIR})
+target_include_directories(${TARGET_NAME} PUBLIC ${PUBLIC_INCLUDE_DIR} PRIVATE ${CMAKE_SOURCE_DIR}/src)
 
 target_sources(
     ${TARGET_NAME}

--- a/src/ethernet/Address.cpp
+++ b/src/ethernet/Address.cpp
@@ -1,4 +1,3 @@
-#include <algorithm>
 #include <ostream>
 
 #include <ethernet/Address.hpp>
@@ -7,20 +6,13 @@ namespace monkas::ethernet
 {
 
 Address::Address()
-    : std::array<uint8_t, ADDR_LEN> {}
+    : m_bytes {}
 {
 }
 
-auto Address::fromBytes(const uint8_t* bytes, size_type len) -> Address
+Address::Address(const Bytes& bytes)
+    : m_bytes {bytes}
 {
-    Address r;
-    std::copy_n(bytes, len, r.begin());
-    return r;
-}
-
-auto Address::fromBytes(const EthernetBytes& bytes) -> Address
-{
-    return fromBytes(bytes.data(), bytes.size());
 }
 
 auto Address::toString() const -> std::string
@@ -31,15 +23,20 @@ auto Address::toString() const -> std::string
     int i = 0;
     constexpr auto LOWER_NIBBLE_SHIFT = 0x4U;
     constexpr auto UPPER_NIBBLE_MASK = 0xFU;
-    for (const auto octet : *this) {
+    for (const auto octet : m_bytes) {
         buf[idx++] = "0123456789abcdef"[octet >> LOWER_NIBBLE_SHIFT];
         buf[idx++] = "0123456789abcdef"[octet & UPPER_NIBBLE_MASK];
-        if (i < size() - 1) {
+        if (i < ADDR_LEN - 1) {
             buf[idx++] = ':';
         }
         i++;
     }
     return {buf.data(), buf.size()};
+}
+
+auto Address::operator<=>(const Address& other) const -> std::strong_ordering
+{
+    return m_bytes <=> other.m_bytes;
 }
 
 auto operator<<(std::ostream& o, const Address& a) -> std::ostream&

--- a/src/ethernet/Address.test.cpp
+++ b/src/ethernet/Address.test.cpp
@@ -11,8 +11,8 @@ TEST_SUITE("[ethernet::Address]")
     std::array<uint8_t, ADDR_LEN> bytesNull {0, 0, 0, 0, 0, 0};
     std::array<uint8_t, ADDR_LEN> bytesSome {1, 2, 3, 4, 5, 0x1A};
 
-    const auto someAddress = Address::fromBytes(bytesSome);
-    const auto nullAddress = Address::fromBytes(bytesNull);
+    const auto someAddress = Address {bytesSome};
+    const auto nullAddress = Address {bytesNull};
 
     TEST_CASE("toString")
     {

--- a/src/ip/Address.cpp
+++ b/src/ip/Address.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <cstring>
 #include <ostream>
+#include <variant>
 
 #include <arpa/inet.h>
 #include <ip/Address.hpp>
@@ -9,12 +10,15 @@ namespace monkas::ip
 {
 namespace
 {
-constexpr auto V4_MAPPED_PREFIX = std::array<uint8_t, 12> {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff};
-
-auto v4MappedCompare(const Address& v6, const Address& v4) noexcept -> int
+// helper type for std::visit
+template<typename... T>
+struct Overloaded : T...
 {
-    return std::memcmp(v6.data() + V4_MAPPED_PREFIX.size(), v4.data(), v4.addressLength());
-}
+    using T::operator()...;
+};
+template<class... T>
+Overloaded(T...) -> Overloaded<T...>;
+
 }  // namespace
 
 auto asLinuxAf(Family f) -> int
@@ -46,86 +50,118 @@ auto operator<<(std::ostream& o, Family a) -> std::ostream&
     return o;
 }
 
-Address::Address()
-    : std::array<uint8_t, IPV6_ADDR_LEN> {}
+Address::Address() = default;
+
+Address::Address(const IpV4Bytes& bytes)
+    : m_bytes(bytes)
+{
+}
+
+Address::Address(const IpV6Bytes& bytes)
+    : m_bytes(bytes)
 {
 }
 
 Address::operator bool() const
 {
-    return m_family != Family::Unspecified;
+    return !isUnspecified();
+}
+
+auto Address::isV4() const -> bool
+{
+    return std::holds_alternative<IpV4Bytes>(m_bytes);
+}
+
+auto Address::isV6() const -> bool
+{
+    return std::holds_alternative<IpV6Bytes>(m_bytes);
+}
+
+auto Address::isUnspecified() const -> bool
+{
+    return std::holds_alternative<std::monostate>(m_bytes);
 }
 
 auto Address::isMulticast() const -> bool
 {
-    if (isV4() || isMappedV4()) {
-        // IPv4 multicast addresses are in the range
-        constexpr auto V4_MCAST_START = 224;
-        constexpr auto V4_MCAST_END = 239;
-        const auto upperOctetd = operator[](isMappedV4() ? V4_MAPPED_PREFIX.size()
-                                                         : 0);  // Ensure the address is not empty
-        return upperOctetd >= V4_MCAST_START && upperOctetd <= V4_MCAST_END;
-    }
-    if (isV6()) {
-        constexpr auto V6_MCAST_PREFIX = 0xffU;
-        return data()[0] == V6_MCAST_PREFIX;
-    }
-    return false;
+    return std::visit(Overloaded {[](const std::monostate&) { return false; },
+                                  [](const IpV4Bytes& addr)
+                                  {
+                                      // IPv4 multicast addresses are in the range
+                                      constexpr auto V4_MCAST_START = 224;
+                                      constexpr auto V4_MCAST_END = 239;
+                                      const auto upperOctetd = addr[0];
+                                      return upperOctetd >= V4_MCAST_START && upperOctetd <= V4_MCAST_END;
+                                  },
+                                  [](const IpV6Bytes& addr)
+                                  {
+                                      // IPv6 multicast addresses start with 0xff
+                                      constexpr auto V6_MCAST_PREFIX = 0xffU;
+                                      return addr[0] == V6_MCAST_PREFIX;
+                                  }},
+                      m_bytes);
 }
 
 auto Address::isLinkLocal() const -> bool
 {
-    if (m_family == Family::IPv4) {
-        constexpr auto LINK_LOCAL_START = 169;
-        constexpr auto LINK_LOCAL_END = 254;
-        return data()[0] == LINK_LOCAL_START && data()[1] == LINK_LOCAL_END;
-    }
-    if (m_family == Family::IPv6) {
-        constexpr auto V6_LL_PREFIX = 0xfeU;
-        constexpr auto V6_LL_MASK = 0xc0U;
-        constexpr auto V6_LL_BITS = 0x80U;
-        return data()[0] == V6_LL_PREFIX && (data()[1] & V6_LL_MASK) == V6_LL_BITS;
-    }
-    return false;
+    return std::visit(Overloaded {[](const std::monostate&) { return false; },
+                                  [](const IpV4Bytes& addr)
+                                  {
+                                      constexpr auto LINK_LOCAL_START = 169;
+                                      constexpr auto LINK_LOCAL_END = 254;
+                                      return addr[0] == LINK_LOCAL_START && addr[1] == LINK_LOCAL_END;
+                                  },
+                                  [](const IpV6Bytes& addr)
+                                  {
+                                      constexpr auto V6_LL_PREFIX = 0xfeU;
+                                      constexpr auto V6_LL_MASK = 0xc0U;
+                                      constexpr auto V6_LL_BITS = 0x80U;
+                                      return addr[0] == V6_LL_PREFIX && (addr[1] & V6_LL_MASK) == V6_LL_BITS;
+                                  }},
+                      m_bytes);
 }
 
 auto Address::isUniqueLocal() const -> bool
 {
-    if (m_family == Family::IPv6) {
-        // Unique local IPv6 addresses are in fc00::/7 (first 7 bits are 1111 110)
-        // So, check if the first byte & 0xFE == 0xFC
-        constexpr auto V6_UL_PREFIX = 0xFCU;
-        constexpr auto V6_UL_MASK = 0xFEU;
-        return (data()[0] & V6_UL_MASK) == V6_UL_PREFIX;
+    if (!isV6()) {
+        return false;
     }
-    return false;
+    const auto bytes = std::get<IpV6Bytes>(m_bytes);
+
+    // Unique local IPv6 addresses are in fc00::/7 (first 7 bits are 1111 110)
+    // So, check if the first byte & 0xFE == 0xFC
+    constexpr auto V6_UL_PREFIX = 0xFCU;
+    constexpr auto V6_UL_MASK = 0xFEU;
+    return (bytes[0] & V6_UL_MASK) == V6_UL_PREFIX;
 }
 
 auto Address::isLoopback() const -> bool
 {
-    // Loopback address in IPv4 is
-    constexpr uint8_t LOOPBACK_FIRST_OCTET = 127;
-    if (isV4()) {
-        return data()[0] == LOOPBACK_FIRST_OCTET;
-    }
-    if (isMappedV4()) {
-        return data()[V4_MAPPED_PREFIX.size()] == LOOPBACK_FIRST_OCTET;
-    }
-    if (isV6()) {
-        // Loopback address in IPv6 is ::1
-        return std::all_of(cbegin(), cend() - 1, [](uint8_t b) { return b == 0; }) && data()[IPV6_ADDR_LEN - 1] == 1;
-    }
-    return false;
+    return std::visit(Overloaded {[](const std::monostate&) { return false; },
+                                  [](const IpV4Bytes& addr)
+                                  {
+                                      // Loopback address in IPv4 is
+                                      constexpr uint8_t LOOPBACK_FIRST_OCTET = 127;
+                                      return addr[0] == LOOPBACK_FIRST_OCTET;
+                                  },
+                                  [](const IpV6Bytes& addr)
+                                  {
+                                      // Loopback address in IPv6 is ::1
+                                      return std::all_of(
+                                                 addr.cbegin(), addr.cend() - 1, [](uint8_t b) { return b == 0; })
+                                          && addr[IPV6_ADDR_LEN - 1] == 1;
+                                  }},
+                      m_bytes);
 }
 
 auto Address::isBroadcast() const -> bool
 {
-    if (m_family == Family::IPv4) {
-        constexpr uint8_t IPV4_BROADCAST_BYTE = 0xFF;
-        return std::all_of(
-            cbegin(), cbegin() + addressLength(), [](uint8_t byte) { return byte == IPV4_BROADCAST_BYTE; });
+    if (!isV4()) {
+        return false;
     }
-    return false;
+    auto bytes = std::get<IpV4Bytes>(m_bytes);
+    constexpr uint8_t IPV4_BROADCAST_BYTE = 0xFF;
+    return std::all_of(bytes.cbegin(), bytes.cend(), [](uint8_t byte) { return byte == IPV4_BROADCAST_BYTE; });
 }
 
 auto Address::isPrivate() const -> bool
@@ -141,7 +177,7 @@ auto Address::isPrivate() const -> bool
     constexpr uint32_t IPV4_192_168_0_0 = 0xC0A80000;  // 192.168.0.0
     constexpr uint32_t IPV4_192_168_255_255 = 0xC0A8FFFF;  // 192.168.255.255
 
-    if (isV4() || isMappedV4()) {
+    if (isV4()) {
         const auto addr = ipv4();
         if ((addr >= IPV4_10_0_0_0 && addr <= IPV4_10_255_255_255) ||  // 10.0.0.0/8
             (addr >= IPV4_172_16_0_0 && addr <= IPV4_172_31_255_255) ||  // 172.16.0.0/12
@@ -158,7 +194,7 @@ auto Address::isPrivate() const -> bool
 
 auto Address::isDocumentation() const -> bool
 {
-    if (!isV4() && !isMappedV4()) {
+    if (!isV4()) {
         return false;  // Only IPv4 addresses can be documentation addresses
     }
 
@@ -178,132 +214,66 @@ auto Address::isDocumentation() const -> bool
 
 auto Address::family() const -> Family
 {
-    return m_family;
-}
-
-auto Address::addressLength() const -> Address::size_type
-{
-    if (m_family == Family::IPv4) {
-        return IPV4_ADDR_LEN;
-    }
-    if (m_family == Family::IPv6) {
-        return IPV6_ADDR_LEN;
-    }
-    return 0;
-}
-
-auto Address::isMappedV4() const -> bool
-{
-    if (m_family == Family::IPv6) {
-        return std::memcmp(data(), V4_MAPPED_PREFIX.data(), V4_MAPPED_PREFIX.size()) == 0;
-    }
-    return false;
-}
-
-auto Address::toMappedV4() const -> std::optional<Address>
-{
-    if (isV4()) {
-        Address v6;
-        // Set the IPv4-mapped IPv6 prefix: ::ffff:0:0/96
-        std::copy(V4_MAPPED_PREFIX.begin(), V4_MAPPED_PREFIX.end(), v6.begin());
-        std::copy_n(data(), IPV4_ADDR_LEN, v6.begin() + V4_MAPPED_PREFIX.size());
-        v6.m_family = Family::IPv6;
-        return v6;
-    }
-    return std::nullopt;
+    return std::visit(Overloaded {[](const std::monostate&) { return Family::Unspecified; },
+                                  [](const IpV4Bytes&) { return Family::IPv4; },
+                                  [](const IpV6Bytes&) { return Family::IPv6; }},
+                      m_bytes);
 }
 
 auto Address::toString() const -> std::string
 {
-    std::array<char, INET6_ADDRSTRLEN> out {};
-    if (inet_ntop(asLinuxAf(m_family), data(), out.data(), out.size()) != nullptr) {
-        return {out.data()};
-    }
-    return {"Unspecified"};
+    return std::visit(Overloaded {[](const std::monostate&) { return std::string("Unspecified"); },
+                                  [](const IpV4Bytes& addr)
+                                  {
+                                      std::array<char, INET_ADDRSTRLEN> buffer {};
+                                      inet_ntop(AF_INET, addr.data(), buffer.data(), buffer.size());
+                                      return std::string(buffer.data());
+                                  },
+                                  [](const IpV6Bytes& addr)
+                                  {
+                                      std::array<char, INET6_ADDRSTRLEN> buffer {};
+                                      inet_ntop(AF_INET6, addr.data(), buffer.data(), buffer.size());
+                                      return std::string(buffer.data());
+                                  }},
+                      m_bytes);
 }
 
 auto Address::fromString(const std::string& address) -> Address
 {
-    std::array<uint8_t, IPV6_ADDR_LEN> addr {};
-    if (inet_pton(AF_INET, address.data(), addr.data()) == 1) {
-        return Address::fromBytes(addr.data(), IPV4_ADDR_LEN);
+    {
+        IpV4Bytes addr {};
+        if (inet_pton(AF_INET, address.data(), addr.data()) == 1) {
+            return Address(addr);
+        }
     }
-    if (inet_pton(AF_INET6, address.data(), addr.data()) == 1) {
-        return Address::fromBytes(addr.data(), IPV6_ADDR_LEN);
-    }
-    return {};
-}
-
-auto Address::fromBytes(const uint8_t* bytes, size_type len) -> Address
-{
-    if (len == IPV6_ADDR_LEN || len == IPV4_ADDR_LEN) {
-        Address a;
-        std::copy_n(bytes, len, a.begin());
-        a.m_family = (len == IPV6_ADDR_LEN ? Family::IPv6 : Family::IPv4);
-        return a;
+    {
+        IpV6Bytes addr {};
+        if (inet_pton(AF_INET6, address.data(), addr.data()) == 1) {
+            return Address(addr);
+        }
     }
     return {};
-}
-
-auto Address::fromBytes(const IpV4Bytes& bytes) -> Address
-{
-    return fromBytes(bytes.data(), bytes.size());
-}
-
-auto Address::fromBytes(const IpV6Bytes& bytes) -> Address
-{
-    return fromBytes(bytes.data(), bytes.size());
 }
 
 auto Address::operator<=>(const Address& rhs) const noexcept -> std::strong_ordering
 {
-    if (m_family == rhs.m_family) {
-        const auto len = addressLength();
-        if (len == 0) {
-            return std::strong_ordering::equal;
-        }
-        return std::memcmp(data(), rhs.data(), len) <=> 0;
-    }
-
-    if (isMappedV4() && rhs.isV4()) {
-        return v4MappedCompare(*this, rhs) <=> 0;
-    }
-
-    if (rhs.isMappedV4() && isV4()) {
-        return 0 <=> v4MappedCompare(rhs, *this);
-    }
-
-    return m_family <=> rhs.m_family;
+    return m_bytes <=> rhs.m_bytes;
 }
 
 auto Address::ipv4() const -> uint32_t
 {
-    if (!isV4() && !isMappedV4()) {
-        return 0;
+    if (!isV4()) {
+        return 0;  // Not an IPv4 address, return 0
     }
-    auto offset = 0U;
 
-    if (isMappedV4()) {
-        offset = V4_MAPPED_PREFIX.size();
-    }
-    return (static_cast<uint32_t>(data()[0 + offset]) << 24U) | (static_cast<uint32_t>(data()[1 + offset]) << 16U)
-        | (static_cast<uint32_t>(data()[2 + offset]) << 8U) | static_cast<uint32_t>(data()[3 + offset]);
-}
-
-auto Address::operator==(const Address& rhs) const noexcept -> bool
-{
-    return (*this <=> rhs) == std::strong_ordering::equal;
+    const auto bytes = std::get<IpV4Bytes>(m_bytes);
+    return (static_cast<uint32_t>(bytes[0]) << 24U) | (static_cast<uint32_t>(bytes[1]) << 16U)
+        | (static_cast<uint32_t>(bytes[2]) << 8U) | static_cast<uint32_t>(bytes[3]);
 }
 
 auto operator<<(std::ostream& o, const Address& a) -> std::ostream&
 {
-    std::array<char, INET6_ADDRSTRLEN> buf {};
-    if (inet_ntop(asLinuxAf(a.family()), a.data(), buf.data(), buf.size()) != nullptr) {
-        o << buf.data();
-    } else {
-        o << "Unspecified";
-    }
-    return o;
+    return o << a.toString();
 }
 
 }  // namespace monkas::ip

--- a/src/ip/Address.cpp
+++ b/src/ip/Address.cpp
@@ -90,7 +90,8 @@ auto Address::isMulticast() const -> bool
                                       // IPv4 multicast addresses are in the range
                                       constexpr auto V4_MCAST_START = 224;
                                       constexpr auto V4_MCAST_END = 239;
-                                      const auto upperOctetd = addr[0];
+                                      const auto upperOctet = addr[0];
+                                      return upperOctet >= V4_MCAST_START && upperOctet <= V4_MCAST_END;
                                       return upperOctetd >= V4_MCAST_START && upperOctetd <= V4_MCAST_END;
                                   },
                                   [](const IpV6Bytes& addr)

--- a/src/ip/Address.cpp
+++ b/src/ip/Address.cpp
@@ -5,22 +5,10 @@
 
 #include <arpa/inet.h>
 #include <ip/Address.hpp>
+#include <overloaded/Overloaded.hpp>
 
 namespace monkas::ip
 {
-namespace
-{
-// helper type for std::visit
-template<typename... T>
-struct Overloaded : T...
-{
-    using T::operator()...;
-};
-template<class... T>
-Overloaded(T...) -> Overloaded<T...>;
-
-}  // namespace
-
 auto asLinuxAf(Family f) -> int
 {
     switch (f) {
@@ -92,7 +80,6 @@ auto Address::isMulticast() const -> bool
                                       constexpr auto V4_MCAST_END = 239;
                                       const auto upperOctet = addr[0];
                                       return upperOctet >= V4_MCAST_START && upperOctet <= V4_MCAST_END;
-                                      return upperOctetd >= V4_MCAST_START && upperOctetd <= V4_MCAST_END;
                                   },
                                   [](const IpV6Bytes& addr)
                                   {

--- a/src/ip/Address.test.cpp
+++ b/src/ip/Address.test.cpp
@@ -20,18 +20,15 @@ TEST_SUITE("[ip::Address]")
     std::array<uint8_t, 16> bytesV6CountUp {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16};
     std::array<uint8_t, 16> bytesV6CountDown {16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1};
 
-    std::array<uint8_t, 16> bytesLocalhostV4mapped {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 127, 0, 0, 1};
-
-    const auto any4 = Address::fromBytes(bytesAny4);
-    const auto any6 = Address::fromBytes(bytesAny6);
-    const auto localhost4 = Address::fromBytes(bytesLocalhost4);
-    const auto localhost4OtherSubnet = Address::fromBytes(bytesLocalhost4OtherSubnet);
-    const auto localHost6 = Address::fromBytes(bytesLocalHost6);
-    const auto localhostV4mapped = Address::fromBytes(bytesLocalhostV4mapped);
-    const auto countUpV4 = Address::fromBytes(bytesV4CountUp);
-    const auto countDownV4 = Address::fromBytes(bytesV4CountDown);
-    const auto countUpV6 = Address::fromBytes(bytesV6CountUp);
-    const auto countDownV6 = Address::fromBytes(bytesV6CountDown);
+    const auto any4 = Address(bytesAny4);
+    const auto any6 = Address(bytesAny6);
+    const auto localhost4 = Address(bytesLocalhost4);
+    const auto localhost4OtherSubnet = Address(bytesLocalhost4OtherSubnet);
+    const auto localHost6 = Address(bytesLocalHost6);
+    const auto countUpV4 = Address(bytesV4CountUp);
+    const auto countDownV4 = Address(bytesV4CountDown);
+    const auto countUpV6 = Address(bytesV6CountUp);
+    const auto countDownV6 = Address(bytesV6CountDown);
     const auto unspecified = Address {};
 
     TEST_CASE("toString")
@@ -51,41 +48,18 @@ TEST_SUITE("[ip::Address]")
     {
         CHECK(localhost4.family() == Family::IPv4);
         CHECK(localHost6.family() == Family::IPv6);
-        CHECK(localhostV4mapped.family() == Family::IPv6);
-    }
-
-    TEST_CASE("addressLength")
-    {
-        CHECK(localhost4.addressLength() == IPV4_ADDR_LEN);
-        CHECK(localHost6.addressLength() == IPV6_ADDR_LEN);
-        CHECK(localhostV4mapped.addressLength() == IPV6_ADDR_LEN);
-    }
-
-    TEST_CASE("isMappedV4")
-    {
-        CHECK(!localhost4.isMappedV4());
-        CHECK(localhostV4mapped.isMappedV4());
-        CHECK(!localHost6.isMappedV4());
-    }
-
-    TEST_CASE("toMappedV4")
-    {
-        CHECK(localhost4.toMappedV4() == localhost4);
-        CHECK(!localHost6.toMappedV4());
     }
 
     TEST_CASE("isV4")
     {
         CHECK(localhost4.isV4());
         CHECK(!localHost6.isV4());
-        CHECK(!localhostV4mapped.isV4());
     }
 
     TEST_CASE("isV6")
     {
         CHECK(!localhost4.isV6());
         CHECK(localHost6.isV6());
-        CHECK(localhostV4mapped.isV6());
     }
 
     TEST_CASE("isUnspecified")
@@ -93,7 +67,6 @@ TEST_SUITE("[ip::Address]")
         CHECK(unspecified.isUnspecified());
         CHECK(!localhost4.isUnspecified());
         CHECK(!localHost6.isUnspecified());
-        CHECK(!localhostV4mapped.isUnspecified());
     }
 
     TEST_CASE("isMulticast")
@@ -107,7 +80,6 @@ TEST_SUITE("[ip::Address]")
         CHECK(!unspecified.isMulticast());
         CHECK(!localhost4.isMulticast());
         CHECK(!localHost6.isMulticast());
-        CHECK(!localhostV4mapped.isMulticast());
         CHECK(!any4.isMulticast());
         CHECK(!any6.isMulticast());
     }
@@ -122,7 +94,6 @@ TEST_SUITE("[ip::Address]")
         CHECK(!unspecified.isLinkLocal());
         CHECK(!localhost4.isLinkLocal());
         CHECK(!localHost6.isLinkLocal());
-        CHECK(!localhostV4mapped.isLinkLocal());
         CHECK(!any4.isLinkLocal());
         CHECK(!any6.isLinkLocal());
     }
@@ -135,7 +106,6 @@ TEST_SUITE("[ip::Address]")
         CHECK(!unspecified.isUniqueLocal());
         CHECK(!localhost4.isUniqueLocal());
         CHECK(!localHost6.isUniqueLocal());
-        CHECK(!localhostV4mapped.isUniqueLocal());
         CHECK(!any4.isUniqueLocal());
         CHECK(!any6.isUniqueLocal());
     }
@@ -154,7 +124,6 @@ TEST_SUITE("[ip::Address]")
     {
         CHECK(localhost4.isLoopback());
         CHECK(localHost6.isLoopback());
-        CHECK(localhostV4mapped.isLoopback());
         CHECK(Address::fromString("127.253.253.123").isLoopback());
     }
 
@@ -163,7 +132,6 @@ TEST_SUITE("[ip::Address]")
         CHECK(Address::fromString("192.168.0.1").isPrivate());
         CHECK(Address::fromString("172.16.0.1").isPrivate());
         CHECK(Address::fromString("10.0.0.1").isPrivate());
-        CHECK(Address::fromString("10.0.0.1").toMappedV4().value().isPrivate());
     }
 
     TEST_CASE("isDocumentation")
@@ -171,14 +139,13 @@ TEST_SUITE("[ip::Address]")
         CHECK(Address::fromString("192.0.2.1").isDocumentation());
         CHECK(Address::fromString("198.51.100.1").isDocumentation());
         CHECK(Address::fromString("203.0.113.1").isDocumentation());
-        CHECK(Address::fromString("203.0.113.1").toMappedV4().value().isDocumentation());
     }
+
     TEST_CASE("operator bool")
     {
         CHECK(!unspecified);
         CHECK(localhost4);
         CHECK(localHost6);
-        CHECK(localhostV4mapped);
         CHECK(any4);
         CHECK(any6);
         CHECK(countUpV4);
@@ -189,10 +156,9 @@ TEST_SUITE("[ip::Address]")
 
     TEST_CASE("operator ==")
     {
+        CHECK(unspecified == unspecified);
         CHECK(localhost4 == localhost4);
-        CHECK(localhost4 == localhostV4mapped);
-        CHECK(localhostV4mapped == localhost4);
-        CHECK(localhostV4mapped == localhostV4mapped);
+        CHECK(localHost6 == localHost6);
     }
 
     TEST_CASE("operator !=")
@@ -203,7 +169,6 @@ TEST_SUITE("[ip::Address]")
         CHECK(localhost4 != localHost6);
         CHECK(unspecified != localhost4);
         CHECK(unspecified != localHost6);
-        CHECK_FALSE(localhostV4mapped != localhost4);
     }
 
     TEST_CASE("operator <")
@@ -222,8 +187,6 @@ TEST_SUITE("[ip::Address]")
         CHECK(countUpV6 <= countDownV6);
         CHECK(countUpV4 <= countDownV4);
         CHECK(localhost4 <= localhost4);
-        CHECK(localhost4 <= localhostV4mapped);
-        CHECK(localhostV4mapped <= localhost4);
         CHECK(localhost4 <= localHost6);
     }
 
@@ -245,8 +208,6 @@ TEST_SUITE("[ip::Address]")
         CHECK(localhost4 >= unspecified);
         CHECK(localhost4OtherSubnet >= localhost4);
         CHECK(localHost6 >= localhost4);
-        CHECK(localhostV4mapped >= localhost4);
-        CHECK(localhost4 >= localhostV4mapped);
     }
 }
 

--- a/src/ip/Address.test.cpp
+++ b/src/ip/Address.test.cpp
@@ -127,20 +127,6 @@ TEST_SUITE("[ip::Address]")
         CHECK(Address::fromString("127.253.253.123").isLoopback());
     }
 
-    TEST_CASE("isPrivate")
-    {
-        CHECK(Address::fromString("192.168.0.1").isPrivate());
-        CHECK(Address::fromString("172.16.0.1").isPrivate());
-        CHECK(Address::fromString("10.0.0.1").isPrivate());
-    }
-
-    TEST_CASE("isDocumentation")
-    {
-        CHECK(Address::fromString("192.0.2.1").isDocumentation());
-        CHECK(Address::fromString("198.51.100.1").isDocumentation());
-        CHECK(Address::fromString("203.0.113.1").isDocumentation());
-    }
-
     TEST_CASE("operator bool")
     {
         CHECK(!unspecified);

--- a/src/monitor/Attributes.cpp
+++ b/src/monitor/Attributes.cpp
@@ -74,17 +74,16 @@ auto Attributes::getU64(uint16_t type) const -> std::optional<uint64_t>
 
 auto Attributes::getEthernetAddress(uint16_t type) const -> std::optional<ethernet::Address>
 {
-    return getPayload<ethernet::ADDR_LEN>(type).transform([](const auto& arr)
-                                                          { return ethernet::Address::fromBytes(arr); });
+    return getPayload<ethernet::ADDR_LEN>(type).transform([](const auto& arr) { return ethernet::Address(arr); });
 }
 
 auto Attributes::getIpV6Address(uint16_t type) const -> std::optional<ip::Address>
 {
-    return getPayload<ip::IPV6_ADDR_LEN>(type).transform([](const auto& arr) { return ip::Address::fromBytes(arr); });
+    return getPayload<ip::IPV6_ADDR_LEN>(type).transform([](const auto& arr) { return ip::Address(arr); });
 }
 
 auto Attributes::getIpV4Address(uint16_t type) const -> std::optional<ip::Address>
 {
-    return getPayload<ip::IPV4_ADDR_LEN>(type).transform([](const auto& arr) { return ip::Address::fromBytes(arr); });
+    return getPayload<ip::IPV4_ADDR_LEN>(type).transform([](const auto& arr) { return ip::Address(arr); });
 }
 }  // namespace monkas::monitor

--- a/src/network/Address.cpp
+++ b/src/network/Address.cpp
@@ -47,11 +47,6 @@ auto Address::isUnspecified() const -> bool
     return m_ip.isUnspecified();
 }
 
-auto Address::isMappedV4() const -> bool
-{
-    return m_ip.isMappedV4();
-}
-
 auto Address::ip() const -> const ip::Address&
 {
     return m_ip;

--- a/src/network/Address.test.cpp
+++ b/src/network/Address.test.cpp
@@ -15,8 +15,8 @@ TEST_SUITE("[network::Address]")
     std::array<uint8_t, 4> someIpV4 {192, 168, 17, 1};
     std::array<uint8_t, 4> someBroadcast {192, 168, 17, 255};
 
-    const auto someV4 = ip::Address::fromBytes(someIpV4);
-    const auto someBroadcastV4 = ip::Address::fromBytes(someBroadcast);
+    const auto someV4 = ip::Address(someIpV4);
+    const auto someBroadcastV4 = ip::Address(someBroadcast);
     const auto someV6 = ip::Address::fromString("2001:db8::1");
     const Address addrV6 {someV6, someBroadcastV4, 24, scope, 5, 0};
     const Address addrV4 {someV4, someBroadcastV4, 24, scope, 10, 1};
@@ -52,12 +52,6 @@ TEST_SUITE("[network::Address]")
         CHECK(defaultAddress.isUnspecified());
         CHECK(!addrV6.isUnspecified());
         CHECK(!addrV4.isUnspecified());
-    }
-
-    TEST_CASE("isMappedV4")
-    {
-        CHECK(!addrV4.isMappedV4());
-        CHECK(!defaultAddress.isMappedV4());
     }
 
     TEST_CASE("ip")

--- a/src/overloaded/Overloaded.hpp
+++ b/src/overloaded/Overloaded.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+// helper type for std::visit
+template<typename... T>
+struct Overloaded : T...
+{
+    using T::operator()...;
+};
+
+template<class... T>
+Overloaded(T...) -> Overloaded<T...>;


### PR DESCRIPTION
Closes #121

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified Ethernet and IP address classes by replacing static factory methods with direct constructors and encapsulating internal data using modern structures.
  - Removed legacy support and methods related to IPv4-mapped IPv6 addresses across all address types.
  - Enhanced address comparison, classification, and string conversion logic for improved consistency and maintainability.

- **Bug Fixes**
  - Improved accuracy and reliability of address property checks and comparisons.

- **Tests**
  - Updated tests to use new address construction methods and removed tests for deprecated IPv4-mapped IPv6 address features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->