### PR TITLE
Change broadcast variable to std::optional in parseAddressMessage method

### DIFF
--- a/src/monitor/NetworkMonitor.cpp
+++ b/src/monitor/NetworkMonitor.cpp
@@ -448,7 +448,7 @@ void NetworkMonitor::parseAddressMessage(const nlmsghdr* nlhdr, const ifaddrmsg*
 
     uint32_t flags = ifa->ifa_flags;  // will be overwritten if IFA_FLAGS is present
     ip::Address address;
-    std::optional<ip::Address> broadcast;
+    std::optional<ip::Address> broadcast = std::nullopt;  // will be overwritten if IFA_BROADCAST is present
     uint8_t prot = IFAPROT_UNSPEC;  // will be overwritten if IFA_PROTO is present
 
     auto& cacheEntry = ensureNameCurrent(ifa->ifa_index, attributes.getString(IFA_LABEL));

--- a/src/monitor/NetworkMonitor.cpp
+++ b/src/monitor/NetworkMonitor.cpp
@@ -448,7 +448,7 @@ void NetworkMonitor::parseAddressMessage(const nlmsghdr* nlhdr, const ifaddrmsg*
 
     uint32_t flags = ifa->ifa_flags;  // will be overwritten if IFA_FLAGS is present
     ip::Address address;
-    ip::Address broadcast;
+    std::optional<ip::Address> broadcast;
     uint8_t prot = IFAPROT_UNSPEC;  // will be overwritten if IFA_PROTO is present
 
     auto& cacheEntry = ensureNameCurrent(ifa->ifa_index, attributes.getString(IFA_LABEL));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved handling of broadcast address information to better reflect cases where the broadcast address may be absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->