### PR TITLE
refactor: Add query methods to `ethernet::Address`, refactor `NetworkInterfaceStatusTracker`, expand tests

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,8 +9,16 @@ reviews:
   poem: true
   review_status: false
   collapse_walkthrough: true
+  auto_assign_reviewers: true
   auto_review:
-    enabled: true
+    enabled: false
+    auto_incremental_review: false
     drafts: false
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: true
+
 chat:
   auto_reply: true

--- a/include/monkas/ethernet/Address.hpp
+++ b/include/monkas/ethernet/Address.hpp
@@ -19,6 +19,8 @@ class Address
     Address();
     explicit Address(const Bytes& bytes);
 
+    [[nodiscard]] auto allZeroes() const -> bool;
+    [[nodiscard]] auto isBroadcast() const -> bool;
     [[nodiscard]] auto toString() const -> std::string;
 
     auto operator<=>(const Address& other) const -> std::strong_ordering;

--- a/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
+++ b/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
@@ -91,7 +91,7 @@ class NetworkInterfaceStatusTracker
     std::string m_name;
     ethernet::Address m_macAddress;
     ethernet::Address m_broadcastAddress;
-    OperationalState m_opeationalState {OperationalState::Unknown};
+    OperationalState m_operationalState {OperationalState::Unknown};
     Addresses m_networkAddresses;
     std::optional<ip::Address> m_gateway;
     std::chrono::time_point<std::chrono::steady_clock> m_lastChanged;

--- a/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
+++ b/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
@@ -57,7 +57,7 @@ class NetworkInterfaceStatusTracker
     void setName(const std::string& name);
 
     [[nodiscard]] auto operationalState() const -> OperationalState;
-    void setOperationalState(OperationalState operstate);
+    void setOperationalState(OperationalState operationalState);
 
     [[nodiscard]] auto macAddress() const -> const ethernet::Address&;
     void setMacAddress(const ethernet::Address& address);
@@ -88,12 +88,10 @@ class NetworkInterfaceStatusTracker
   private:
     void touch(DirtyFlag flag);
 
-    // TODO: only use public api
-    friend auto operator<<(std::ostream& o, const NetworkInterfaceStatusTracker& s) -> std::ostream&;
     std::string m_name;
     ethernet::Address m_macAddress;
     ethernet::Address m_broadcastAddress;
-    OperationalState m_operState {OperationalState::Unknown};
+    OperationalState m_opeationalState {OperationalState::Unknown};
     Addresses m_networkAddresses;
     std::optional<ip::Address> m_gateway;
     std::chrono::time_point<std::chrono::steady_clock> m_lastChanged;
@@ -125,6 +123,7 @@ using DirtyFlag = NetworkInterfaceStatusTracker::DirtyFlag;
 using DirtyFlags = NetworkInterfaceStatusTracker::DirtyFlags;
 auto operator<<(std::ostream& o, DirtyFlag d) -> std::ostream&;
 auto operator<<(std::ostream& o, const DirtyFlags& d) -> std::ostream&;
+auto operator<<(std::ostream& o, const NetworkInterfaceStatusTracker& s) -> std::ostream&;
 
 }  // namespace monkas::monitor
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,6 +52,7 @@ if(BUILD_TESTS)
             ethernet/Address.test.cpp
             ip/Address.test.cpp
             network/Address.test.cpp
+            monitor/NetworkInterfaceStatusTracker.test.cpp
             watchable/Watchable.test.cpp
     )
     target_link_libraries(

--- a/src/ethernet/Address.cpp
+++ b/src/ethernet/Address.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <ostream>
 
 #include <ethernet/Address.hpp>
@@ -13,6 +14,17 @@ Address::Address()
 Address::Address(const Bytes& bytes)
     : m_bytes {bytes}
 {
+}
+
+auto Address::allZeroes() const -> bool
+{
+    return std::all_of(m_bytes.begin(), m_bytes.end(), [](const uint8_t byte) { return byte == 0; });
+}
+
+auto Address::isBroadcast() const -> bool
+{
+    constexpr uint8_t BROADCAST_BYTE = 0xFF;
+    return std::all_of(m_bytes.begin(), m_bytes.end(), [](const uint8_t byte) { return byte == BROADCAST_BYTE; });
 }
 
 auto Address::toString() const -> std::string

--- a/src/ethernet/Address.cpp
+++ b/src/ethernet/Address.cpp
@@ -1,5 +1,5 @@
-#include <cstdint>
 #include <ostream>
+#include <algorithm>
 
 #include <ethernet/Address.hpp>
 
@@ -18,13 +18,13 @@ Address::Address(const Bytes& bytes)
 
 auto Address::allZeroes() const -> bool
 {
-    return std::all_of(m_bytes.begin(), m_bytes.end(), [](const uint8_t byte) { return byte == 0; });
+    return std::ranges::all_of(m_bytes, [](const uint8_t byte) { return byte == 0; });
 }
 
 auto Address::isBroadcast() const -> bool
 {
     constexpr uint8_t BROADCAST_BYTE = 0xFF;
-    return std::all_of(m_bytes.begin(), m_bytes.end(), [](const uint8_t byte) { return byte == BROADCAST_BYTE; });
+    return std::ranges::all_of(m_bytes, [](const uint8_t byte) { return byte == BROADCAST_BYTE; });
 }
 
 auto Address::toString() const -> std::string

--- a/src/ethernet/Address.cpp
+++ b/src/ethernet/Address.cpp
@@ -1,5 +1,5 @@
-#include <ostream>
 #include <algorithm>
+#include <ostream>
 
 #include <ethernet/Address.hpp>
 

--- a/src/ethernet/Address.test.cpp
+++ b/src/ethernet/Address.test.cpp
@@ -13,6 +13,24 @@ TEST_SUITE("[ethernet::Address]")
 
     const auto someAddress = Address {bytesSome};
     const auto nullAddress = Address {bytesNull};
+    const auto defaultAddress = Address {};
+
+    TEST_CASE("default constructor")
+    {
+        CHECK(defaultAddress.allZeroes());
+    }
+
+    TEST_CASE("constructor with bytes")
+    {
+        CHECK(!someAddress.allZeroes());
+    }
+
+    TEST_CASE("isBroadcast")
+    {
+        CHECK(!someAddress.isBroadcast());
+        CHECK(!nullAddress.isBroadcast());
+        CHECK(!defaultAddress.isBroadcast());
+    }
 
     TEST_CASE("toString")
     {

--- a/src/monitor/NetworkInterfaceStatusTracker.cpp
+++ b/src/monitor/NetworkInterfaceStatusTracker.cpp
@@ -66,13 +66,13 @@ void NetworkInterfaceStatusTracker::setName(const std::string& name)
 
 auto NetworkInterfaceStatusTracker::operationalState() const -> OperationalState
 {
-    return m_opeationalState;
+    return m_operationalState;
 }
 
 void NetworkInterfaceStatusTracker::setOperationalState(const OperationalState operationalState)
 {
-    if (m_opeationalState != operationalState) {
-        m_opeationalState = operationalState;
+    if (m_operationalState != operationalState) {
+        m_operationalState = operationalState;
         touch(DirtyFlag::OperationalStateChanged);
         logTrace(operationalState, this, "operational state changed to");
         m_nerdstats.operationalStateChanges++;

--- a/src/monitor/NetworkInterfaceStatusTracker.cpp
+++ b/src/monitor/NetworkInterfaceStatusTracker.cpp
@@ -64,18 +64,17 @@ void NetworkInterfaceStatusTracker::setName(const std::string& name)
     }
 }
 
-// TODO: fallback to flags
 auto NetworkInterfaceStatusTracker::operationalState() const -> OperationalState
 {
-    return m_operState;
+    return m_opeationalState;
 }
 
-void NetworkInterfaceStatusTracker::setOperationalState(const OperationalState operstate)
+void NetworkInterfaceStatusTracker::setOperationalState(const OperationalState operationalState)
 {
-    if (m_operState != operstate) {
-        m_operState = operstate;
+    if (m_opeationalState != operationalState) {
+        m_opeationalState = operationalState;
         touch(DirtyFlag::OperationalStateChanged);
-        logTrace(operstate, this, "operational state changed to");
+        logTrace(operationalState, this, "operational state changed to");
         m_nerdstats.operationalStateChanges++;
     }
 }
@@ -92,7 +91,7 @@ auto NetworkInterfaceStatusTracker::broadcastAddress() const -> const ethernet::
 
 void NetworkInterfaceStatusTracker::setMacAddress(const ethernet::Address& address)
 {
-    if (m_macAddress != address) {
+    if (m_macAddress != address || address.allZeroes()) {
         m_macAddress = address;
         touch(DirtyFlag::MacAddressChanged);
         logTrace(address, this, "mac address changed to");
@@ -102,7 +101,7 @@ void NetworkInterfaceStatusTracker::setMacAddress(const ethernet::Address& addre
 
 void NetworkInterfaceStatusTracker::setBroadcastAddress(const ethernet::Address& address)
 {
-    if (m_broadcastAddress != address) {
+    if (m_broadcastAddress != address || address.allZeroes()) {
         m_broadcastAddress = address;
         touch(DirtyFlag::BroadcastAddressChanged);
         logTrace(address, this, "broadcast address changed to");
@@ -332,12 +331,12 @@ auto operator<<(std::ostream& o, const DirtyFlags& d) -> std::ostream&
 auto operator<<(std::ostream& o, const NetworkInterfaceStatusTracker& s) -> std::ostream&
 {
     o << s.name();
-    o << " mac " << s.m_macAddress;
-    o << " brd " << s.m_broadcastAddress;
-    if (!s.m_networkAddresses.empty()) {
+    o << " mac " << s.macAddress();
+    o << " brd " << s.broadcastAddress();
+    if (!s.networkAddresses().empty()) {
         o << " [";
         bool first = true;
-        for (const auto& a : s.m_networkAddresses) {
+        for (const auto& a : s.networkAddresses()) {
             if (!first) {
                 o << ", ";
             }
@@ -346,10 +345,10 @@ auto operator<<(std::ostream& o, const NetworkInterfaceStatusTracker& s) -> std:
         }
         o << "]";
     }
-    if (s.m_gateway.has_value()) {
-        o << " default via " << s.m_gateway.value();
+    if (s.gatewayAddress().has_value()) {
+        o << " default via " << s.gatewayAddress().value();
     }
-    o << " op " << toString(s.m_operState) << "(" << static_cast<int>(s.m_operState) << ")";
+    o << " op " << toString(s.operationalState()) << "(" << static_cast<int>(s.operationalState()) << ")";
     o << " age " << s.age().count();
     o << " dirty " << dirtyFlagsToString(s.dirtyFlags());
     return o;

--- a/src/monitor/NetworkInterfaceStatusTracker.test.cpp
+++ b/src/monitor/NetworkInterfaceStatusTracker.test.cpp
@@ -1,0 +1,73 @@
+#include <doctest/doctest.h>
+#include <ethernet/Address.hpp>
+#include <ip/Address.hpp>
+#include <monitor/NetworkInterfaceStatusTracker.hpp>
+
+namespace
+{
+
+// NOLINTBEGIN(*)
+using namespace monkas::monitor;
+using namespace monkas;
+
+TEST_SUITE("[monitor::NetworkInterfaceStatusTracker]")
+{
+    NetworkInterfaceStatusTracker tracker;
+
+    TEST_CASE("NetworkInterfaceStatusTracker default state")
+    {
+        CHECK(tracker.hasName() == false);
+        CHECK(tracker.name() == "");
+        CHECK(tracker.isDirty() == false);
+    }
+
+    TEST_CASE("NetworkInterfaceStatusTracker set and check name")
+    {
+        tracker.setName("eth0");
+        CHECK(tracker.hasName());
+        CHECK(tracker.name() == "eth0");
+        CHECK(tracker.isDirty());
+        CHECK(tracker.isDirty(DirtyFlag::NameChanged));
+    }
+
+    TEST_CASE("NetworkInterfaceStatusTracker operational state")
+    {
+        tracker.setOperationalState(NetworkInterfaceStatusTracker::OperationalState::Up);
+        CHECK(tracker.operationalState() == NetworkInterfaceStatusTracker::OperationalState::Up);
+        CHECK(tracker.isDirty(DirtyFlag::OperationalStateChanged));
+    }
+
+    TEST_CASE("NetworkInterfaceStatusTracker MAC address")
+    {
+        ethernet::Address addr;
+        tracker.setMacAddress(addr);
+        CHECK(tracker.macAddress() == addr);
+        CHECK(tracker.isDirty(DirtyFlag::MacAddressChanged));
+    }
+
+    TEST_CASE("NetworkInterfaceStatusTracker broadcast address")
+    {
+        ethernet::Address brd;
+        tracker.setBroadcastAddress(brd);
+        CHECK(tracker.broadcastAddress() == brd);
+        CHECK(tracker.isDirty(DirtyFlag::BroadcastAddressChanged));
+    }
+
+    TEST_CASE("NetworkInterfaceStatusTracker clearFlag")
+    {
+        tracker.setName("eth0");
+        CHECK(tracker.isDirty(DirtyFlag::NameChanged));
+        tracker.clearFlag(DirtyFlag::NameChanged);
+        CHECK_FALSE(tracker.isDirty(DirtyFlag::NameChanged));
+    }
+
+    TEST_CASE("NetworkInterfaceStatusTracker age")
+    {
+        tracker.setName("eth0");
+        auto age = tracker.age();
+        CHECK(age.count() >= 0);  // Ensure age is non-negative
+    }
+}
+
+// NOLINTEND(*)
+}  // namespace


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added methods to check if an Ethernet address is all zeroes or a broadcast address.

- **Bug Fixes**
  - Improved update conditions for MAC and broadcast addresses to handle zeroed addresses correctly.

- **Refactor**
  - Enhanced naming consistency and encapsulation in network interface status tracking.
  - Streamlined output formatting for network interface status objects.

- **Tests**
  - Introduced unit tests for network interface status tracking.
  - Expanded tests for Ethernet address functionality.

- **Chores**
  - Updated configuration to adjust automation and review settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->