### PR TITLE
feat: Add network interface link flag tracking and notification system

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -75,6 +75,9 @@ auto main(int argc, char* argv[]) -> int
     std::ignore = mon.addInterfacesWatcher([](const Interfaces& interfaces)
                                            { spdlog::info("Interfaces changed to: {}", fmt::join(interfaces, ", ")); },
                                            InitialSnapshotMode::InitialSnapshot);
+    std::ignore = mon.addLinkFlagsWatcher([](const Interface& iface, const LinkFlags& flags)
+                                          { spdlog::info("{} changed link flags to {}", iface, flags); },
+                                          InitialSnapshotMode::InitialSnapshot);
     std::ignore = mon.addOperationalStateWatcher([](const Interface& iface, OperationalState state)
                                                  { spdlog::info("{} changed operational state to {}", iface, state); },
                                                  InitialSnapshotMode::InitialSnapshot);

--- a/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
+++ b/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
@@ -57,6 +57,9 @@ class NetworkInterfaceStatusTracker
         PortSet,
         AutoMedia,
         Dynamic,
+        LowerUp,
+        Dormant,
+        Echo,
         // NOTE: keep last
         FlagsCount,
     };

--- a/include/monkas/monitor/NetworkMonitor.hpp
+++ b/include/monkas/monitor/NetworkMonitor.hpp
@@ -52,6 +52,11 @@ using InterfacesNotifier = Watchable<const Interfaces>;
 using InterfacesWatcher = InterfacesNotifier::Watcher;
 using InterfacesWatcherToken = InterfacesNotifier::Token;
 
+using LinkFlags = NetworkInterfaceStatusTracker::LinkFlags;
+using LinkFlagsNotifier = Watchable<const network::Interface, const LinkFlags>;
+using LinkFlagsWatcher = LinkFlagsNotifier::Watcher;
+using LinkFlagsWatcherToken = LinkFlagsNotifier::Token;
+
 using OperationalState = NetworkInterfaceStatusTracker::OperationalState;
 using OperationalStateNotifier = Watchable<const network::Interface, OperationalState>;
 using OperationalStateWatcher = OperationalStateNotifier::Watcher;
@@ -89,6 +94,11 @@ class NetworkMonitor
         const InterfacesWatcher& watcher, InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot)
         -> InterfacesWatcherToken;
     void removeInterfacesWatcher(const InterfacesWatcherToken& token);
+
+    [[nodiscard]] auto addLinkFlagsWatcher(const LinkFlagsWatcher& watcher,
+                                           InitialSnapshotMode initialSnapshot = InitialSnapshotMode::NoInitialSnapshot)
+        -> LinkFlagsWatcherToken;
+    void removeLinkFlagsWatcher(const LinkFlagsWatcherToken& token);
 
     [[nodiscard]] auto addOperationalStateWatcher(
         const OperationalStateWatcher& watcher,
@@ -193,6 +203,7 @@ class NetworkMonitor
 
     RuntimeOptions m_runtimeOptions;
     InterfacesNotifier m_interfacesNotifier;
+    LinkFlagsNotifier m_linkFlagsNotifier;
     OperationalStateNotifier m_operationalStateNotifier;
     NetworkAddressNotifier m_networkAddressNotifier;
     GatewayAddressNotifier m_gatewayAddressNotifier;

--- a/include/monkas/util/FlagSet.hpp
+++ b/include/monkas/util/FlagSet.hpp
@@ -11,6 +11,7 @@ template<typename Enum>
 class FlagSet
 {
     static_assert(std::is_scoped_enum_v<Enum>, "Template parameter must be a scoped enum");
+    static_assert(requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
     static constexpr size_t FLAG_COUNT = static_cast<size_t>(Enum::FlagsCount);
 
   public:

--- a/include/monkas/util/FlagSet.hpp
+++ b/include/monkas/util/FlagSet.hpp
@@ -1,0 +1,69 @@
+#pragma once
+#include <bitset>
+#include <compare>
+#include <sstream>
+#include <type_traits>
+#include <utility>
+
+namespace monkas::util
+{
+template<typename Enum>
+class FlagSet
+{
+    static_assert(std::is_scoped_enum_v<Enum>, "Template parameter must be a scoped enum");
+    static constexpr size_t FLAG_COUNT = static_cast<size_t>(Enum::FlagsCount);
+
+  public:
+    using EnumType = Enum;
+
+    FlagSet() = default;
+
+    explicit FlagSet(uint32_t bits)
+        : m_flags(bits)
+    {
+    }
+
+    [[nodiscard]] constexpr auto size() const -> size_t { return FLAG_COUNT; }
+
+    [[nodiscard]] constexpr auto count() const -> size_t { return m_flags.count(); }
+
+    [[nodiscard]] constexpr auto none() const -> bool { return m_flags.none(); }
+
+    [[nodiscard]] constexpr auto any() const -> bool { return m_flags.any(); }
+
+    auto set(EnumType flag) -> void { m_flags.set(std::to_underlying(flag)); }
+
+    auto reset(EnumType flag) -> void { m_flags.reset(std::to_underlying(flag)); }
+
+    [[nodiscard]] auto test(EnumType flag) const -> bool { return m_flags.test(std::to_underlying(flag)); }
+
+    [[nodiscard]] auto toString() const -> std::string
+    {
+        std::ostringstream oss;
+        bool first = true;
+        for (size_t i = m_flags._Find_first(); i < FLAG_COUNT; i = m_flags._Find_next(i)) {
+            if (m_flags.test(i)) {
+                if (!first) {
+                    oss << "|";
+                }
+                first = false;
+                oss << static_cast<Enum>(i);
+            }
+        }
+        if (first) {
+            return "None";
+        }
+        return oss.str();
+    }
+
+    [[nodiscard]] auto operator<=>(const FlagSet& other) const -> std::strong_ordering
+    {
+        return m_flags <=> other.m_flags;
+    }
+
+    [[nodiscard]] auto operator==(const FlagSet& other) const -> bool = default;
+
+  private:
+    std::bitset<FLAG_COUNT> m_flags {};
+};
+}  // namespace monkas::util

--- a/include/monkas/util/FlagSet.hpp
+++ b/include/monkas/util/FlagSet.hpp
@@ -19,7 +19,7 @@ class FlagSet
 
     FlagSet() = default;
 
-    explicit FlagSet(uint32_t bits)
+    explicit FlagSet(uint64_t bits)
         : m_flags(bits)
     {
     }
@@ -42,15 +42,15 @@ class FlagSet
     {
         std::ostringstream oss;
         bool first = true;
-    for (size_t i = 0; i < FLAG_COUNT; ++i) {
-        if (m_flags.test(i)) {
-            if (!first) {
-                oss << "|";
+        for (size_t i = 0; i < FLAG_COUNT; ++i) {
+            if (m_flags.test(i)) {
+                if (!first) {
+                    oss << "|";
+                }
+                first = false;
+                oss << static_cast<Enum>(i);
             }
-            first = false;
-            oss << static_cast<Enum>(i);
         }
-    }
         if (first) {
             return "None";
         }

--- a/include/monkas/util/FlagSet.hpp
+++ b/include/monkas/util/FlagSet.hpp
@@ -41,15 +41,15 @@ class FlagSet
     {
         std::ostringstream oss;
         bool first = true;
-        for (size_t i = m_flags._Find_first(); i < FLAG_COUNT; i = m_flags._Find_next(i)) {
-            if (m_flags.test(i)) {
-                if (!first) {
-                    oss << "|";
-                }
-                first = false;
-                oss << static_cast<Enum>(i);
+    for (size_t i = 0; i < FLAG_COUNT; ++i) {
+        if (m_flags.test(i)) {
+            if (!first) {
+                oss << "|";
             }
+            first = false;
+            oss << static_cast<Enum>(i);
         }
+    }
         if (first) {
             return "None";
         }

--- a/include/monkas/util/FlagSet.hpp
+++ b/include/monkas/util/FlagSet.hpp
@@ -11,7 +11,8 @@ template<typename Enum>
 class FlagSet
 {
     static_assert(std::is_scoped_enum_v<Enum>, "Template parameter must be a scoped enum");
-    static_assert(requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
+    static_assert(
+        requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
     static constexpr size_t FLAG_COUNT = static_cast<size_t>(Enum::FlagsCount);
 
   public:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ set(PUBLIC_HEADERS
     ${PUBLIC_INCLUDE_DIR}/monitor/NetworkMonitor.hpp
     ${PUBLIC_INCLUDE_DIR}/network/Address.hpp
     ${PUBLIC_INCLUDE_DIR}/network/Interface.hpp
+    ${PUBLIC_INCLUDE_DIR}/util/FlagSet.hpp
     ${PUBLIC_INCLUDE_DIR}/watchable/Watchable.hpp
 )
 

--- a/src/monitor/Attributes.hpp
+++ b/src/monitor/Attributes.hpp
@@ -1,6 +1,4 @@
 #pragma once
-#include <algorithm>
-#include <array>
 #include <cstdint>
 #include <optional>
 #include <vector>

--- a/src/monitor/NetworkInterfaceStatusTracker.cpp
+++ b/src/monitor/NetworkInterfaceStatusTracker.cpp
@@ -347,6 +347,12 @@ auto operator<<(std::ostream& o, NetworkInterfaceStatusTracker::LinkFlag l) -> s
             return o << "AutoMedia";
         case Dynamic:
             return o << "Dynamic";
+        case LowerUp:
+            return o << "LowerUp";
+        case Dormant:
+            return o << "Dormant";
+        case Echo:
+            return o << "Echo";
         case FlagsCount:
         default:
             return o << "UnknownLinkFlag: 0x" << std::hex << static_cast<uint8_t>(l);

--- a/src/monitor/NetworkMonitor.cpp
+++ b/src/monitor/NetworkMonitor.cpp
@@ -5,12 +5,12 @@
 #include <fmt/std.h>
 #include <ip/Address.hpp>
 #include <libmnl/libmnl.h>
+#include <linux/if.h>
 #include <linux/if_link.h>
 #include <linux/rtnetlink.h>
 #include <memory.h>
 #include <monitor/Attributes.hpp>
 #include <monitor/NetworkMonitor.hpp>
-#include <net/if.h>
 #include <net/if_arp.h>
 #include <spdlog/common.h>
 #include <spdlog/spdlog.h>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added monitoring and notification support for network interface link flags, allowing users to watch for changes in interface status such as "up", "broadcast", or "promiscuous" modes.
  - Enhanced status reporting to include detailed link flag states for each network interface.

- **Bug Fixes**
  - Improved internal handling of status flags for more accurate and reliable interface state tracking.

- **Chores**
  - Removed unused header includes to streamline dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->