### PR TITLE
refactor: Replace std::bitset with util::FlagSet and enum with enum class for flags

### DIFF
--- a/examples/cli/main.cpp
+++ b/examples/cli/main.cpp
@@ -53,7 +53,7 @@ auto main(int argc, char* argv[]) -> int
     }
     constexpr auto FLUSH_EVERY = std::chrono::seconds(5);
     spdlog::flush_every(FLUSH_EVERY);
-    RuntimeOptions options;
+    RuntimeFlags options;
     if (FLAGS_nerdstats) {
         options.set(RuntimeFlag::StatsForNerds);
     }

--- a/include/monkas/monitor/NetworkMonitor.hpp
+++ b/include/monkas/monitor/NetworkMonitor.hpp
@@ -11,11 +11,8 @@
 #include <monitor/NetworkInterfaceStatusTracker.hpp>
 #include <network/Interface.hpp>
 #include <sys/types.h>
+#include <util/FlagSet.hpp>
 #include <watchable/Watchable.hpp>
-
-// TODO: sometimes an enthernet interface comes up with Unknown operstate, ip link shows the same info, what do we want
-// to do in this case?
-// TODO: consider ENOBUFS errno from recv as resync point
 
 struct mnl_socket;
 struct nlmsghdr;
@@ -32,7 +29,7 @@ enum class InitialSnapshotMode : uint8_t
     InitialSnapshot = 1,
 };
 
-enum RuntimeFlag : uint8_t
+enum class RuntimeFlag : uint8_t
 {
     StatsForNerds,
     PreferredFamilyV4,
@@ -44,7 +41,7 @@ enum RuntimeFlag : uint8_t
     FlagsCount,
 };
 
-using RuntimeOptions = std::bitset<static_cast<size_t>(RuntimeFlag::FlagsCount)>;
+using RuntimeFlags = util::FlagSet<RuntimeFlag>;
 
 using Interfaces = std::set<network::Interface>;
 
@@ -85,7 +82,7 @@ using EnumerationDoneWatcherToken = EnumerationDoneNotifier::Token;
 class NetworkMonitor
 {
   public:
-    explicit NetworkMonitor(const RuntimeOptions& options);
+    explicit NetworkMonitor(const RuntimeFlags& options);
     void enumerateInterfaces();
     void run();
     void stop();
@@ -126,8 +123,8 @@ class NetworkMonitor
 
     void removeBroadcastAddressWatcher(const BroadcastAddressWatcherToken& token);
 
-    // enumeration done watcher is called when enumeration is done, or immediately if enumeration is already done
-    // the optional return value is used to indicate that enumeration is already done
+    // enumeration done watcher is called when enumeration is done, or immediately if enumeration is
+    // already done the optional return value is used to indicate that enumeration is already done
     [[nodiscard]] auto addEnumerationDoneWatcher(const EnumerationDoneWatcher& watcher)
         -> std::optional<EnumerationDoneWatcherToken>;
     void removeEnumerationDoneWatcher(const EnumerationDoneWatcherToken& token);
@@ -201,7 +198,7 @@ class NetworkMonitor
         uint64_t routeMessagesSeen {};
     } m_stats;
 
-    RuntimeOptions m_runtimeOptions;
+    RuntimeFlags m_runtimeOptions;
     InterfacesNotifier m_interfacesNotifier;
     LinkFlagsNotifier m_linkFlagsNotifier;
     OperationalStateNotifier m_operationalStateNotifier;

--- a/src/monitor/NetworkMonitor.cpp
+++ b/src/monitor/NetworkMonitor.cpp
@@ -55,8 +55,8 @@ auto ensureMnlSocket(bool nonBlocking) -> mnl_socket*
 }
 }  // namespace
 
-NetworkMonitor::NetworkMonitor(const RuntimeOptions& options)
-    : m_mnlSocket {ensureMnlSocket(options.test(NonBlocking)), mnl_socket_close}
+NetworkMonitor::NetworkMonitor(const RuntimeFlags& options)
+    : m_mnlSocket {ensureMnlSocket(options.test(RuntimeFlag::NonBlocking)), mnl_socket_close}
     , m_portid {mnl_socket_get_portid(m_mnlSocket.get())}
     , m_receiveBuffer(RECEIVE_SOCKET_BUFFER_SIZE)
     , m_sendBuffer(SEND_SOCKET_BUFFER_SIZE)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated internal handling of runtime flags for network monitoring, improving type safety and maintainability.
- **Style**
	- Improved code comments and removed obsolete notes for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->