### PR TITLE
feat: Refactor network address flags and protocols to use strongly typed enums

### DIFF
--- a/include/monkas/network/Address.hpp
+++ b/include/monkas/network/Address.hpp
@@ -34,7 +34,7 @@ enum class AddressFlag : uint8_t
     Tentative,
     Permanent,
     ManagedTemporaryAddress,
-    NoPefixRoute,
+    NoPrefixRoute,
     MulticastAutoJoin,
     StablePrivacy,
     FlagsCount,

--- a/include/monkas/network/Address.hpp
+++ b/include/monkas/network/Address.hpp
@@ -5,6 +5,7 @@
 
 #include <fmt/ostream.h>
 #include <ip/Address.hpp>
+#include <util/FlagSet.hpp>
 
 namespace monkas::network
 {
@@ -22,6 +23,32 @@ auto operator<<(std::ostream& o, Scope a) -> std::ostream&;
 
 auto fromRtnlScope(uint8_t rtnlScope) -> Scope;
 
+enum class AddressFlag : uint8_t
+{
+    Temporary,
+    NoDuplicateAddressDetection,
+    Optimistic,
+    HomeAddress,
+    DuplicateAddressDetectionFailed,
+    Deprecated,
+    Tentative,
+    Permanent,
+    ManagedTemporaryAddress,
+    NoPefixRoute,
+    MulticastAutoJoin,
+    StablePrivacy,
+    FlagsCount,
+};
+using AddressFlags = util::FlagSet<AddressFlag>;
+
+enum class AddressAssignmentProtocol : uint8_t
+{
+    Unspecified,
+    KernelLoopback,
+    KernelRouterAdvertisement,
+    KernelLinkLocal,
+};
+
 class Address
 {
   public:
@@ -30,8 +57,8 @@ class Address
             std::optional<ip::Address> broadcast,
             uint8_t prefixLen,
             Scope scope,
-            uint32_t flags,
-            uint8_t proto);
+            const AddressFlags& flags,
+            AddressAssignmentProtocol proto);
 
     [[nodiscard]] auto family() const -> Family;
 
@@ -42,8 +69,15 @@ class Address
     [[nodiscard]] auto broadcast() const -> std::optional<ip::Address>;
     [[nodiscard]] auto prefixLength() const -> uint8_t;
     [[nodiscard]] auto scope() const -> Scope;
-    [[nodiscard]] auto flags() const -> uint32_t;
-    [[nodiscard]] auto proto() const -> uint8_t;
+    [[nodiscard]] auto flags() const -> AddressFlags;
+    [[nodiscard]] auto addressAssignmentProtocol() const -> AddressAssignmentProtocol;
+
+    [[nodiscard]] auto isLinkLocal() const -> bool;
+    [[nodiscard]] auto isGlobal() const -> bool;
+    [[nodiscard]] auto isSiteLocal() const -> bool;
+    [[nodiscard]] auto isHostLocal() const -> bool;
+
+    [[nodiscard]] auto toString() const -> std::string;
 
     [[nodiscard]] auto operator<=>(const Address& other) const -> std::strong_ordering;
     [[nodiscard]] auto operator==(const Address& other) const -> bool = default;
@@ -53,15 +87,33 @@ class Address
     std::optional<ip::Address> m_brd;
     uint8_t m_prefixlen {};
     Scope m_scope {Scope::Nowhere};
-    uint32_t m_flags {};
-    uint8_t m_prot {0};
+    AddressFlags m_flags;
+    AddressAssignmentProtocol m_prot {AddressAssignmentProtocol::Unspecified};
 };
 
 auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;
+auto operator<<(std::ostream& o, AddressFlag a) -> std::ostream&;
+auto operator<<(std::ostream& o, const AddressFlags& a) -> std::ostream&;
+auto operator<<(std::ostream& o, AddressAssignmentProtocol a) -> std::ostream&;
 
 }  // namespace monkas::network
 
 template<>
 struct fmt::formatter<monkas::network::Address> : fmt::ostream_formatter
+{
+};
+
+template<>
+struct fmt::formatter<monkas::network::AddressFlag> : fmt::ostream_formatter
+{
+};
+
+template<>
+struct fmt::formatter<monkas::network::AddressFlags> : fmt::ostream_formatter
+{
+};
+
+template<>
+struct fmt::formatter<monkas::network::AddressAssignmentProtocol> : fmt::ostream_formatter
 {
 };

--- a/include/monkas/util/FlagSet.hpp
+++ b/include/monkas/util/FlagSet.hpp
@@ -11,8 +11,9 @@ template<typename Enum>
 class FlagSet
 {
     static_assert(std::is_scoped_enum_v<Enum>, "Template parameter must be a scoped enum");
-    static_assert(
-        requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
+    static_assert(requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
+    static_assert(std::is_integral_v<std::underlying_type_t<Enum>>, "Enum must have an integral underlying type");
+    static_assert(std::to_underlying(Enum::FlagsCount) <= 32, "FlagsCount must not exceed 32");
     static constexpr size_t FLAG_COUNT = static_cast<size_t>(Enum::FlagsCount);
 
   public:
@@ -20,10 +21,12 @@ class FlagSet
 
     FlagSet() = default;
 
-    explicit FlagSet(uint64_t bits)
+    explicit FlagSet(uint32_t bits)
         : m_flags(bits)
     {
     }
+
+    [[nodiscard]] constexpr auto toU32() const -> uint64_t { return m_flags.to_ulong(); }
 
     [[nodiscard]] constexpr auto size() const -> size_t { return FLAG_COUNT; }
 
@@ -60,7 +63,7 @@ class FlagSet
 
     [[nodiscard]] auto operator<=>(const FlagSet& other) const -> std::strong_ordering
     {
-        return m_flags <=> other.m_flags;
+        return m_flags.to_ullong() <=> other.m_flags.to_ullong();
     }
 
     [[nodiscard]] auto operator==(const FlagSet& other) const -> bool = default;

--- a/include/monkas/util/FlagSet.hpp
+++ b/include/monkas/util/FlagSet.hpp
@@ -12,7 +12,8 @@ class FlagSet
 {
     static_assert(std::is_scoped_enum_v<Enum>, "Template parameter must be a scoped enum");
     static_assert(std::is_integral_v<std::underlying_type_t<Enum>>, "Enum must have an integral underlying type");
-    static_assert(requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
+    static_assert(
+        requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
     static_assert(std::to_underlying(Enum::FlagsCount) <= 32, "FlagsCount must not exceed 32");
     static constexpr size_t FLAG_COUNT = static_cast<size_t>(Enum::FlagsCount);
 

--- a/include/monkas/util/FlagSet.hpp
+++ b/include/monkas/util/FlagSet.hpp
@@ -11,9 +11,8 @@ template<typename Enum>
 class FlagSet
 {
     static_assert(std::is_scoped_enum_v<Enum>, "Template parameter must be a scoped enum");
-    static_assert(
-        requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
     static_assert(std::is_integral_v<std::underlying_type_t<Enum>>, "Enum must have an integral underlying type");
+    static_assert(requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
     static_assert(std::to_underlying(Enum::FlagsCount) <= 32, "FlagsCount must not exceed 32");
     static constexpr size_t FLAG_COUNT = static_cast<size_t>(Enum::FlagsCount);
 
@@ -27,7 +26,7 @@ class FlagSet
     {
     }
 
-    [[nodiscard]] constexpr auto toU32() const -> uint64_t { return m_flags.to_ulong(); }
+    [[nodiscard]] constexpr auto toU32() const -> uint32_t { return m_flags.to_ulong(); }
 
     [[nodiscard]] constexpr auto size() const -> size_t { return FLAG_COUNT; }
 
@@ -64,7 +63,7 @@ class FlagSet
 
     [[nodiscard]] auto operator<=>(const FlagSet& other) const -> std::strong_ordering
     {
-        return m_flags.to_ullong() <=> other.m_flags.to_ullong();
+        return m_flags.to_ulong() <=> other.m_flags.to_ulong();
     }
 
     [[nodiscard]] auto operator==(const FlagSet& other) const -> bool = default;

--- a/include/monkas/util/FlagSet.hpp
+++ b/include/monkas/util/FlagSet.hpp
@@ -11,7 +11,8 @@ template<typename Enum>
 class FlagSet
 {
     static_assert(std::is_scoped_enum_v<Enum>, "Template parameter must be a scoped enum");
-    static_assert(requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
+    static_assert(
+        requires { Enum::FlagsCount; }, "Enum must define FlagsCount enumerator");
     static_assert(std::is_integral_v<std::underlying_type_t<Enum>>, "Enum must have an integral underlying type");
     static_assert(std::to_underlying(Enum::FlagsCount) <= 32, "FlagsCount must not exceed 32");
     static constexpr size_t FLAG_COUNT = static_cast<size_t>(Enum::FlagsCount);

--- a/src/monitor/NetworkMonitor.cpp
+++ b/src/monitor/NetworkMonitor.cpp
@@ -16,6 +16,7 @@
 #include <spdlog/spdlog.h>
 
 #include "ethernet/Address.hpp"
+#include "network/Address.hpp"
 
 namespace monkas::monitor
 {
@@ -515,8 +516,12 @@ void NetworkMonitor::parseAddressMessage(const nlmsghdr* nlhdr, const ifaddrmsg*
     if (const auto addressV6Opt = attributes.getIpV6Address(IFA_ADDRESS); addressV6Opt.has_value()) {
         address = addressV6Opt.value();
     }
-    const network::Address networkAddress {
-        address, broadcast, ifa->ifa_prefixlen, network::fromRtnlScope(ifa->ifa_scope), flags, prot};
+    const network::Address networkAddress {address,
+                                           broadcast,
+                                           ifa->ifa_prefixlen,
+                                           network::fromRtnlScope(ifa->ifa_scope),
+                                           network::AddressFlags(flags),
+                                           static_cast<network::AddressAssignmentProtocol>(prot)};
     if (nlhdr->nlmsg_type == RTM_NEWADDR) {
         cacheEntry.addNetworkAddress(networkAddress);
     } else if (nlhdr->nlmsg_type == RTM_DELADDR) {

--- a/src/network/Address.cpp
+++ b/src/network/Address.cpp
@@ -149,7 +149,7 @@ auto operator<<(std::ostream& o, const AddressFlag a) -> std::ostream&
             return o << "Permanent";
         case ManagedTemporaryAddress:
             return o << "ManagedTemporaryAddress";
-        case NoPefixRoute:
+        case NoPrefixRoute:
             return o << "NoPrefixRoute";
         case MulticastAutoJoin:
             return o << "MulticastAutoJoin";

--- a/src/network/Address.cpp
+++ b/src/network/Address.cpp
@@ -9,10 +9,10 @@ namespace monkas::network
 
 Address::Address(const ip::Address& address,
                  std::optional<ip::Address> broadcast,
-                 uint8_t prefixLen,
-                 Scope scope,
-                 uint32_t flags,
-                 uint8_t proto)
+                 const uint8_t prefixLen,
+                 const Scope scope,
+                 const AddressFlags& flags,
+                 const AddressAssignmentProtocol proto)
     : m_ip {address}
     , m_brd {broadcast}
     , m_prefixlen {prefixLen}
@@ -57,12 +57,12 @@ auto Address::scope() const -> Scope
     return m_scope;
 }
 
-auto Address::flags() const -> uint32_t
+auto Address::flags() const -> AddressFlags
 {
     return m_flags;
 }
 
-auto Address::proto() const -> uint8_t
+auto Address::addressAssignmentProtocol() const -> AddressAssignmentProtocol
 {
     return m_prot;
 }
@@ -127,6 +127,61 @@ auto operator<<(std::ostream& o, Scope a) -> std::ostream&
     return o;
 }
 
+auto operator<<(std::ostream& o, const AddressFlag a) -> std::ostream&
+{
+    using enum AddressFlag;
+    switch (a) {
+        case Temporary:
+            return o << "Temporary";
+        case NoDuplicateAddressDetection:
+            return o << "NoDuplicateAddressDetection";
+        case Optimistic:
+            return o << "Optimistic";
+        case HomeAddress:
+            return o << "HomeAddress";
+        case DuplicateAddressDetectionFailed:
+            return o << "DuplicateAddressDetectionFailed";
+        case Deprecated:
+            return o << "Deprecated";
+        case Tentative:
+            return o << "Tentative";
+        case Permanent:
+            return o << "Permanent";
+        case ManagedTemporaryAddress:
+            return o << "ManagedTemporaryAddress";
+        case NoPefixRoute:
+            return o << "NoPrefixRoute";
+        case MulticastAutoJoin:
+            return o << "MulticastAutoJoin";
+        case StablePrivacy:
+            return o << "StablePrivacy";
+        default:
+            return o << "Unknown Flag: 0x" << std::hex << static_cast<int>(a);
+    }
+}
+
+auto operator<<(std::ostream& o, const AddressFlags& a) -> std::ostream&
+{
+    return o << a.toString();
+}
+
+auto operator<<(std::ostream& o, AddressAssignmentProtocol a) -> std::ostream&
+{
+    using enum AddressAssignmentProtocol;
+    switch (a) {
+        case Unspecified:
+            return o << "Unspecified";
+        case KernelLoopback:
+            return o << "KernelLoopback";
+        case KernelRouterAdvertisement:
+            return o << "KernelRouterAdvertisement";
+        case KernelLinkLocal:
+            return o << "KernelLinkLocal";
+        default:
+            return o << "Unknown Address AddressAssignmentProtocol: 0x" << std::hex << static_cast<int>(a);
+    }
+}
+
 auto operator<<(std::ostream& o, const Address& a) -> std::ostream&
 {
     o << a.family() << " " << a.ip() << "/" << static_cast<int>(a.prefixLength());
@@ -134,27 +189,12 @@ auto operator<<(std::ostream& o, const Address& a) -> std::ostream&
     if (a.broadcast().has_value()) {
         o << " brd " << a.broadcast().value();
     }
-    // TODO: to readable
-    if (a.flags() != 0U) {
-        o << " f 0x" << std::hex << a.flags() << std::dec;
+    if (a.flags().any()) {
+        o << " <" << a.flags() << ">";
     }
-    switch (a.proto()) {
-        case IFAPROT_UNSPEC:
-            break;
-        case IFAPROT_KERNEL_LO:
-            o << " kernel_lo";
-            break;
-        case IFAPROT_KERNEL_RA:
-            o << " kernel_ra";
-            break;
-        case IFAPROT_KERNEL_LL:
-            o << " kernel_ll";
-            break;
-        default:
-            o << " prot unknown: " << static_cast<int>(a.proto());
-            break;
+    if (a.addressAssignmentProtocol() != AddressAssignmentProtocol::Unspecified) {
+        o << " proto " << a.addressAssignmentProtocol();
     }
-
     return o;
 }
 

--- a/src/network/Address.test.cpp
+++ b/src/network/Address.test.cpp
@@ -18,8 +18,9 @@ TEST_SUITE("[network::Address]")
     const auto someV4 = ip::Address(someIpV4);
     const auto someBroadcastV4 = ip::Address(someBroadcast);
     const auto someV6 = ip::Address::fromString("2001:db8::1");
-    const Address addrV6 {someV6, std::nullopt, 24, scope, 5, 0};
-    const Address addrV4 {someV4, someBroadcastV4, 24, scope, 10, 1};
+    const Address addrV6 {someV6, std::nullopt, 24, scope, AddressFlags(5), AddressAssignmentProtocol::Unspecified};
+    const Address addrV4 {
+        someV4, someBroadcastV4, 24, scope, AddressFlags(10), AddressAssignmentProtocol::KernelLinkLocal};
     const Address defaultAddress {};
 
     TEST_CASE("family")
@@ -67,15 +68,17 @@ TEST_SUITE("[network::Address]")
 
     TEST_CASE("flags")
     {
-        CHECK(addrV4.flags() == 10);
-        CHECK(defaultAddress.flags() == 0);
+        INFO("Address flags ", addrV4.flags().toString());
+        CHECK(addrV4.flags().test(AddressFlag::HomeAddress));
+        CHECK(addrV4.flags().test(AddressFlag::NoDuplicateAddressDetection));
+        CHECK(defaultAddress.flags().none());
     }
 
     TEST_CASE("proto")
     {
-        CHECK(addrV4.proto() == 1);
-        CHECK(addrV6.proto() == 0);
-        CHECK(defaultAddress.proto() == 0);
+        CHECK(addrV4.addressAssignmentProtocol() == AddressAssignmentProtocol::KernelLinkLocal);
+        CHECK(addrV6.addressAssignmentProtocol() == AddressAssignmentProtocol::Unspecified);
+        CHECK(defaultAddress.addressAssignmentProtocol() == AddressAssignmentProtocol::Unspecified);
     }
 
     TEST_CASE("operator ==")


### PR DESCRIPTION
Closes #52 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced strongly typed enums and flag sets for network address flags and assignment protocols.
  - Added convenience methods to query address scope and convert addresses to string representations.
  - Enhanced output formatting for address-related types.

- **Bug Fixes**
  - Improved type safety by replacing raw integral types with strongly typed enums and wrappers.

- **Tests**
  - Updated tests to use new enums and flag sets, and improved output for flag checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->