### PR TITLE
chore: Update CMake configuration to require C++23 for doctest executable

### DIFF
--- a/external/doctest/CMakeLists.txt
+++ b/external/doctest/CMakeLists.txt
@@ -25,7 +25,7 @@ set_property(
         OUTPUT_NAME
             doctest
 )
-target_compile_features(doctest_exe PRIVATE cxx_std_20)
+target_compile_features(doctest_exe PRIVATE cxx_std_23)
 
 add_test(
     NAME doctest


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to require C++23 standard for testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->