### PR TITLE
refactor: Rename isLinkLocal to isUnicastLinkLocal in Address class and tests

### DIFF
--- a/include/monkas/ip/Address.hpp
+++ b/include/monkas/ip/Address.hpp
@@ -45,7 +45,7 @@ class Address
     [[nodiscard]] auto isV6() const -> bool;
 
     [[nodiscard]] auto isMulticast() const -> bool;
-    [[nodiscard]] auto isLinkLocal() const -> bool;
+    [[nodiscard]] auto isUnicastLinkLocal() const -> bool;
     [[nodiscard]] auto isUniqueLocal() const -> bool;
     [[nodiscard]] auto isLoopback() const -> bool;
     [[nodiscard]] auto isBroadcast() const -> bool;

--- a/src/ip/Address.cpp
+++ b/src/ip/Address.cpp
@@ -82,7 +82,7 @@ auto Address::isMulticast() const -> bool
                       m_bytes);
 }
 
-auto Address::isLinkLocal() const -> bool
+auto Address::isUnicastLinkLocal() const -> bool
 {
     return std::visit(Overloaded {[](const V4Bytes& addr)
                                   {

--- a/src/ip/Address.test.cpp
+++ b/src/ip/Address.test.cpp
@@ -76,7 +76,7 @@ TEST_SUITE("[ip::Address]")
         CHECK(!any6.isMulticast());
     }
 
-    TEST_CASE("isLinkLocal")
+    TEST_CASE("isUnicastLinkLocal")
     {
         CHECK(Address::fromString("169.254.0.1").isUnicastLinkLocal());
         CHECK(Address::fromString("169.254.255.255").isUnicastLinkLocal());

--- a/src/ip/Address.test.cpp
+++ b/src/ip/Address.test.cpp
@@ -78,16 +78,16 @@ TEST_SUITE("[ip::Address]")
 
     TEST_CASE("isLinkLocal")
     {
-        CHECK(Address::fromString("169.254.0.1").isLinkLocal());
-        CHECK(Address::fromString("169.254.255.255").isLinkLocal());
-        CHECK(Address::fromString("fe80::1").isLinkLocal());
-        CHECK(Address::fromString("fe80::2").isLinkLocal());
-        CHECK(Address::fromString("fe80::3").isLinkLocal());
-        CHECK(!defaultCtor.isLinkLocal());
-        CHECK(!localhost4.isLinkLocal());
-        CHECK(!localHost6.isLinkLocal());
-        CHECK(!any4.isLinkLocal());
-        CHECK(!any6.isLinkLocal());
+        CHECK(Address::fromString("169.254.0.1").isUnicastLinkLocal());
+        CHECK(Address::fromString("169.254.255.255").isUnicastLinkLocal());
+        CHECK(Address::fromString("fe80::1").isUnicastLinkLocal());
+        CHECK(Address::fromString("fe80::2").isUnicastLinkLocal());
+        CHECK(Address::fromString("fe80::3").isUnicastLinkLocal());
+        CHECK(!defaultCtor.isUnicastLinkLocal());
+        CHECK(!localhost4.isUnicastLinkLocal());
+        CHECK(!localHost6.isUnicastLinkLocal());
+        CHECK(!any4.isUnicastLinkLocal());
+        CHECK(!any6.isUnicastLinkLocal());
     }
 
     TEST_CASE("isUniqueLocal")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Renamed the method for checking unicast link-local addresses to improve clarity in the interface.  
* **Tests**
  * Updated tests to use the new method name for unicast link-local address checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->