### PR TITLE
chore: Replace fmt::ostream_formatter with ostream_formatter in formatter specializations

### DIFF
--- a/include/monkas/ethernet/Address.hpp
+++ b/include/monkas/ethernet/Address.hpp
@@ -35,6 +35,6 @@ auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;
 }  // namespace monkas::ethernet
 
 template<>
-struct fmt::formatter<monkas::ethernet::Address> : fmt::ostream_formatter
+struct fmt::formatter<monkas::ethernet::Address> : ostream_formatter
 {
 };

--- a/include/monkas/ip/Address.hpp
+++ b/include/monkas/ip/Address.hpp
@@ -63,6 +63,6 @@ auto operator<<(std::ostream& o, const Address& a) -> std::ostream&;
 }  // namespace monkas::ip
 
 template<>
-struct fmt::formatter<monkas::ip::Address> : fmt::ostream_formatter
+struct fmt::formatter<monkas::ip::Address> : ostream_formatter
 {
 };

--- a/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
+++ b/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
@@ -166,36 +166,36 @@ auto operator<<(std::ostream& o, const NetworkInterfaceStatusTracker& s) -> std:
 }  // namespace monkas::monitor
 
 template<>
-struct fmt::formatter<monkas::monitor::NetworkInterfaceStatusTracker> : fmt::ostream_formatter
+struct fmt::formatter<monkas::monitor::NetworkInterfaceStatusTracker> : ostream_formatter
 {
 };
 
 template<>
-struct fmt::formatter<monkas::monitor::OperationalState> : fmt::ostream_formatter
+struct fmt::formatter<monkas::monitor::OperationalState> : ostream_formatter
 {
 };
 
 template<>
-struct fmt::formatter<monkas::monitor::GatewayClearReason> : fmt::ostream_formatter
+struct fmt::formatter<monkas::monitor::GatewayClearReason> : ostream_formatter
 {
 };
 
 template<>
-struct fmt::formatter<monkas::monitor::DirtyFlag> : fmt::ostream_formatter
+struct fmt::formatter<monkas::monitor::DirtyFlag> : ostream_formatter
 {
 };
 
 template<>
-struct fmt::formatter<monkas::monitor::DirtyFlags> : fmt::ostream_formatter
+struct fmt::formatter<monkas::monitor::DirtyFlags> : ostream_formatter
 {
 };
 
 template<>
-struct fmt::formatter<monkas::monitor::LinkFlag> : fmt::ostream_formatter
+struct fmt::formatter<monkas::monitor::LinkFlag> : ostream_formatter
 {
 };
 
 template<>
-struct fmt::formatter<monkas::monitor::NetworkInterfaceStatusTracker::LinkFlags> : fmt::ostream_formatter
+struct fmt::formatter<monkas::monitor::NetworkInterfaceStatusTracker::LinkFlags> : ostream_formatter
 {
 };

--- a/include/monkas/network/Address.hpp
+++ b/include/monkas/network/Address.hpp
@@ -92,21 +92,21 @@ auto operator<<(std::ostream& o, AddressAssignmentProtocol a) -> std::ostream&;
 }  // namespace monkas::network
 
 template<>
-struct fmt::formatter<monkas::network::Address> : fmt::ostream_formatter
+struct fmt::formatter<monkas::network::Address> : ostream_formatter
 {
 };
 
 template<>
-struct fmt::formatter<monkas::network::AddressFlag> : fmt::ostream_formatter
+struct fmt::formatter<monkas::network::AddressFlag> : ostream_formatter
 {
 };
 
 template<>
-struct fmt::formatter<monkas::network::AddressFlags> : fmt::ostream_formatter
+struct fmt::formatter<monkas::network::AddressFlags> : ostream_formatter
 {
 };
 
 template<>
-struct fmt::formatter<monkas::network::AddressAssignmentProtocol> : fmt::ostream_formatter
+struct fmt::formatter<monkas::network::AddressAssignmentProtocol> : ostream_formatter
 {
 };

--- a/include/monkas/network/Interface.hpp
+++ b/include/monkas/network/Interface.hpp
@@ -35,6 +35,6 @@ auto operator<<(std::ostream& os, const Interface& iface) -> std::ostream&;
 }  // namespace monkas::network
 
 template<>
-struct fmt::formatter<monkas::network::Interface> : fmt::ostream_formatter
+struct fmt::formatter<monkas::network::Interface> : ostream_formatter
 {
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal formatting mechanisms for various network-related types to improve consistency. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->