### PR TITLE
docs: Rename README Debian/Ubuntu section; update TOC and anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,24 @@
 <!--toc:start-->
 
 - [monkas](#monkas)
-- [Dependencies](#dependencies)
--## Quick install for debian/ubuntu based distros
-+## Quick installation for debian/ubuntu based distros
 - [Quick Start](#quick-start)
-<!--toc:end-->
+- [Dependencies](#dependencies)
+  - [Quick install](#quick-installation-for-debianubuntu-based-distributions)
+  <!--toc:end-->
 
 # monkas
 
-Netlink Socket experiments using libmnl
+Linux netlink socket experiments using `libmnl`
 
-# Dependencies
+## Quick Start
+
+```console
+cmake -B build -S .
+cmake --build build
+build/examples/cli/monkas
+```
+
+## Dependencies
 
 - [cmake](https://cmake.org/)
 - [libmnl](https://netfilter.org/projects/libmnl/)
@@ -19,16 +26,8 @@ Netlink Socket experiments using libmnl
 - [fmt](https://fmt.dev)
 - [gflags](https://github.com/gflags/gflags)
 
-## Quick install for debian/ubuntu based distros
+### Quick installation for Debian/Ubuntu based distributions
 
 ```console
-sudo apt install build-essential cmake libmnl-dev libspdlog-dev libgflags-dev libfmt-dev
-```
-
-# Quick Start
-
-```console
-cmake -B build -S .
-cmake --build build
-build/examples/cli/monkas
+sudo apt update && sudo apt install build-essential cmake libmnl-dev libspdlog-dev libgflags-dev libfmt-dev
 ```


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Renamed the Debian/Ubuntu quick installation section for clearer wording and consistent capitalization.
  * Updated the Table of Contents to point to the revised section, ensuring links navigate correctly.
  * Synchronized the section heading and TOC entry to improve discoverability and readability.
  * No changes to the actual installation commands or steps; instructions remain the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->