### PR TITLE
chore(ci): CI: unify command line args in tests to use kebab-case

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,7 +171,7 @@ jobs:
 
       - name: CLI example nerdstats/dumppackets
         run: |
-          ./build/examples/cli/monka --log-level=trace --nerdstats --dumppackets --include_non_ieee802 --exit-after-enumeration
+          ./build/examples/cli/monka --log-level=trace --nerdstats --dumppackets --include-non-ieee802 --exit-after-enumeration
 
       - name: JUnit Report
         if: always()

--- a/src/monitor/NetworkMonitor.cpp
+++ b/src/monitor/NetworkMonitor.cpp
@@ -353,7 +353,7 @@ void NetworkMonitor::parseLinkMessage(const nlmsghdr* nlhdr, const ifinfomsg* if
     const auto itfName = attributes.getString(IFLA_IFNAME);
     if (ifi->ifi_type != ARPHRD_ETHER && ifi->ifi_type != ARPHRD_IEEE80211) {
         if (!m_runtimeOptions.test(RuntimeFlag::IncludeNonIeee802)) {
-            spdlog::debug("Discarding interface {}: {} (use --include_non_ieee802 to include)",
+            spdlog::debug("Discarding interface {}: {} (use RuntimeFlag::IncludeNonIeee802 option to include those)",
                           ifi->ifi_index,
                           itfName.value_or("unknown"));
             m_stats.msgsDiscarded++;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow to standardize a CLI flag format used in example invocations, improving consistency across automation and build logs. This maintenance update helps ensure smoother CI runs and clearer diagnostics for contributors.
  * No changes to application behavior, interfaces, or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->