### PR TITLE
fix: Avoid changing ostream state by formatting with fmt::format

### DIFF
--- a/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
+++ b/include/monkas/monitor/NetworkInterfaceStatusTracker.hpp
@@ -154,8 +154,8 @@ using GatewayClearReason = NetworkInterfaceStatusTracker::GatewayClearReason;
 auto operator<<(std::ostream& o, GatewayClearReason r) -> std::ostream&;
 using ChangedFlag = NetworkInterfaceStatusTracker::ChangedFlag;
 using ChangedFlags = NetworkInterfaceStatusTracker::ChangedFlags;
-auto operator<<(std::ostream& o, ChangedFlag d) -> std::ostream&;
-auto operator<<(std::ostream& o, const ChangedFlags& d) -> std::ostream&;
+auto operator<<(std::ostream& o, ChangedFlag c) -> std::ostream&;
+auto operator<<(std::ostream& o, const ChangedFlags& c) -> std::ostream&;
 using LinkFlag = NetworkInterfaceStatusTracker::LinkFlag;
 using LinkFlags = NetworkInterfaceStatusTracker::LinkFlags;
 

--- a/src/monitor/NetworkInterfaceStatusTracker.cpp
+++ b/src/monitor/NetworkInterfaceStatusTracker.cpp
@@ -286,10 +286,10 @@ auto operator<<(std::ostream& o, const GatewayClearReason r) -> std::ostream&
     return o;
 }
 
-auto operator<<(std::ostream& o, ChangedFlag d) -> std::ostream&
+auto operator<<(std::ostream& o, ChangedFlag c) -> std::ostream&
 {
     using enum NetworkInterfaceStatusTracker::ChangedFlag;
-    switch (d) {
+    switch (c) {
         case Name:
             return o << "NameChanged";
         case LinkFlags:
@@ -306,13 +306,13 @@ auto operator<<(std::ostream& o, ChangedFlag d) -> std::ostream&
             return o << "NetworkAddressesChanged";
         case FlagsCount:
         default:
-            return o << "Unknown ChangedFlag: 0x" << std::hex << static_cast<uint8_t>(d);
+            return o << fmt::format("Unknown ChangedFlag: 0x{:02x}", std::to_underlying(c));
     }
 }
 
-auto operator<<(std::ostream& o, const ChangedFlags& d) -> std::ostream&
+auto operator<<(std::ostream& o, const ChangedFlags& c) -> std::ostream&
 {
-    return o << d.toString();
+    return o << c.toString();
 }
 
 auto operator<<(std::ostream& o, NetworkInterfaceStatusTracker::LinkFlag l) -> std::ostream&
@@ -359,7 +359,7 @@ auto operator<<(std::ostream& o, NetworkInterfaceStatusTracker::LinkFlag l) -> s
             return o << "Echo";
         case FlagsCount:
         default:
-            return o << "Unknown LinkFlag: 0x" << std::hex << static_cast<uint8_t>(l);
+            return o << fmt::format("Unknown LinkFlag: 0x{:02x}", std::to_underlying(l));
     }
 }
 

--- a/src/network/Address.cpp
+++ b/src/network/Address.cpp
@@ -1,5 +1,6 @@
 #include <compare>
 #include <ostream>
+#include <utility>
 
 #include <linux/rtnetlink.h>
 #include <network/Address.hpp>
@@ -155,8 +156,9 @@ auto operator<<(std::ostream& o, const AddressFlag a) -> std::ostream&
             return o << "MulticastAutoJoin";
         case StablePrivacy:
             return o << "StablePrivacy";
+        case FlagsCount:
         default:
-            return o << "Unknown Flag: 0x" << std::hex << static_cast<int>(a);
+            return o << fmt::format("Unknown AddressFlag: 0x{:02x}", std::to_underlying(a));
     }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new FlagsCount enum value to improve flag classification.

* **Improvements**
  * Standardized formatting and display for unknown/unsupported network flags across the monitoring subsystem.
  * Minor public-facing signature/parameter renames in diagnostic output to improve consistency while preserving backward compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->